### PR TITLE
Fix/second popup fix

### DIFF
--- a/iframe-frontend/src/components/CloseBtn/CloseBtn.tsx
+++ b/iframe-frontend/src/components/CloseBtn/CloseBtn.tsx
@@ -10,11 +10,12 @@ interface Props {
     withTime?: boolean
     time?: number
     className?: string
+    type?: string
 }
 
 const THIRTY_MIN_MS = 30 * 60 * 1000
 
-const CloseBtn = ({ callback, withTime = true, time, className = '' }: Props) => {
+const CloseBtn = ({ callback, withTime = true, time, className = '', type }: Props) => {
     const { domain, version} = useRouteLoaderData('root') as LoaderData
     const { sendGaEvent } = useGoogleAnalytics()
 
@@ -30,6 +31,7 @@ const CloseBtn = ({ callback, withTime = true, time, className = '' }: Props) =>
 
         const message: Parameters<typeof sendMessage>[0] = { action: ACTIONS.CLOSE, domain}
         if (withTime) message.time = parseTime(time ?? THIRTY_MIN_MS, version)
+        if (type) message.type = type
 
         sendMessage(message)
     }

--- a/iframe-frontend/src/components/Offer/Offer.tsx
+++ b/iframe-frontend/src/components/Offer/Offer.tsx
@@ -89,7 +89,8 @@ const Offer = ({ closeFn }: Props) => {
             iframeUrl,
             token,
             flowId,
-            platformName
+            platformName,
+            quietDomainType: 'd'
         })
 
         sendGaEvent('retailer_shop', {

--- a/iframe-frontend/src/components/Offer/Offer.tsx
+++ b/iframe-frontend/src/components/Offer/Offer.tsx
@@ -90,7 +90,7 @@ const Offer = ({ closeFn }: Props) => {
             token,
             flowId,
             platformName,
-            quietDomainType: 'd'
+            quietDomainType: 'ds'
         })
 
         sendGaEvent('retailer_shop', {

--- a/iframe-frontend/src/components/Offer/Offer.tsx
+++ b/iframe-frontend/src/components/Offer/Offer.tsx
@@ -90,7 +90,7 @@ const Offer = ({ closeFn }: Props) => {
             token,
             flowId,
             platformName,
-            quietDomainType: 'ds'
+            quietDomainType: 'kds'
         })
 
         sendGaEvent('retailer_shop', {

--- a/iframe-frontend/src/pages/Activated/Activated.tsx
+++ b/iframe-frontend/src/pages/Activated/Activated.tsx
@@ -51,7 +51,7 @@ const Activated = () => {
         <div id="activated-container" className={styles.container}>
             <CloseBtn
                 time={isOfferBar ? OB_ACTIVATE_QUIET_TIME : ACTIVATE_QUIET_TIME}
-                type="ds"
+                type="kds"
             />
             <div id="activated-top-container" className={styles.top_container}>
                 {walletAddress ? <div id="activated-wallet-container" className={styles.wallet_container}>

--- a/iframe-frontend/src/pages/Activated/Activated.tsx
+++ b/iframe-frontend/src/pages/Activated/Activated.tsx
@@ -51,6 +51,7 @@ const Activated = () => {
         <div id="activated-container" className={styles.container}>
             <CloseBtn
                 time={isOfferBar ? OB_ACTIVATE_QUIET_TIME : ACTIVATE_QUIET_TIME}
+                type="d"
             />
             <div id="activated-top-container" className={styles.top_container}>
                 {walletAddress ? <div id="activated-wallet-container" className={styles.wallet_container}>

--- a/iframe-frontend/src/pages/Activated/Activated.tsx
+++ b/iframe-frontend/src/pages/Activated/Activated.tsx
@@ -51,7 +51,7 @@ const Activated = () => {
         <div id="activated-container" className={styles.container}>
             <CloseBtn
                 time={isOfferBar ? OB_ACTIVATE_QUIET_TIME : ACTIVATE_QUIET_TIME}
-                type="d"
+                type="ds"
             />
             <div id="activated-top-container" className={styles.top_container}>
                 {walletAddress ? <div id="activated-wallet-container" className={styles.wallet_container}>

--- a/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
@@ -97,7 +97,7 @@ const Offerbar = () => {
       token,
       flowId,
       platformName,
-      quietDomainType,
+      quietDomainType: 'ds',
       isRegex
     })
 

--- a/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
@@ -56,7 +56,7 @@ const Offerbar = () => {
     if (isOptedOut) {
       sendMessage({ action: ACTIONS.CLOSE })
     } else {
-      sendMessage({ action: ACTIONS.CLOSE, domain: ['google.com','google.com'], time: parseTime(THIRTY_MIN_MS, version), type: ['ki','kd'], isRegex: [false, false] })
+      sendMessage({ action: ACTIONS.CLOSE, domain: ['google.com'], time: parseTime(THIRTY_MIN_MS, version), type: ['kdsi'], isRegex: [false] })
     }
   }
 
@@ -97,7 +97,7 @@ const Offerbar = () => {
       token,
       flowId,
       platformName,
-      quietDomainType: 'ds',
+      quietDomainType: 'kds',
       isRegex
     })
 

--- a/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
@@ -31,9 +31,9 @@ const Optout = ({ closeFn, onOptOut }: Props) => {
     const handleOptOut = (duration: typeof durationOptions[0]) => {
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,
-            domain: ['google.com', 'google.com'],
-            type: ["ki", "kd"],
-            isRegex: [false, false],
+            domain: ['google.com'],
+            type: ["kdsi"],
+            isRegex: [false],
             time: +duration.value,
             key: dict[duration.label as keyof typeof dict]
         }

--- a/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
+++ b/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
@@ -116,7 +116,7 @@ const OneStep = () => {
             return
         }
 
-        sendMessage({ action: ACTIONS.ACTIVATE, url, domain, time: parseTime(ACTIVATE_QUIET_TIME, version), redirectUrl })
+        sendMessage({ action: ACTIONS.ACTIVATE, url, domain, time: parseTime(ACTIVATE_QUIET_TIME, version), redirectUrl, quietDomainType: 'd' })
         sendGaEvent('retailer_shop', {
             category: 'user_action',
             action: 'click',

--- a/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
+++ b/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
@@ -116,7 +116,7 @@ const OneStep = () => {
             return
         }
 
-        sendMessage({ action: ACTIONS.ACTIVATE, url, domain, time: parseTime(ACTIVATE_QUIET_TIME, version), redirectUrl, quietDomainType: 'd' })
+        sendMessage({ action: ACTIONS.ACTIVATE, url, domain, time: parseTime(ACTIVATE_QUIET_TIME, version), redirectUrl, quietDomainType: 'ds' })
         sendGaEvent('retailer_shop', {
             category: 'user_action',
             action: 'click',

--- a/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
+++ b/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
@@ -116,7 +116,7 @@ const OneStep = () => {
             return
         }
 
-        sendMessage({ action: ACTIONS.ACTIVATE, url, domain, time: parseTime(ACTIVATE_QUIET_TIME, version), redirectUrl, quietDomainType: 'ds' })
+        sendMessage({ action: ACTIONS.ACTIVATE, url, domain, time: parseTime(ACTIVATE_QUIET_TIME, version), redirectUrl, quietDomainType: 'kds' })
         sendGaEvent('retailer_shop', {
             category: 'user_action',
             action: 'click',


### PR DESCRIPTION
send type in activate and close messages from iframe
in order to handle quietDomains types correctly.
(Now the type is "ds" to support both domains search and content search).