### PR TITLE
fix: remove unused var

### DIFF
--- a/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
@@ -37,7 +37,6 @@ const Offerbar = () => {
     networkUrl,
     isOfferBar,
     searchTermPattern,
-    quietDomainType, 
     isRegex,
     iframeStyle: themeIframeStyle
   } = useRouteLoaderData('root') as LoaderData


### PR DESCRIPTION
This pull request makes a minor cleanup to the `Offerbar` component by removing the unused `quietDomainType` variable from the route loader data destructuring. This helps keep the codebase clean and avoids confusion from unused variables.