### PR TITLE
Fix/link trigger

### DIFF
--- a/extension-files/bringweb3-sdk/.changeset/grumpy-windows-joke.md
+++ b/extension-files/bringweb3-sdk/.changeset/grumpy-windows-joke.md
@@ -1,0 +1,5 @@
+---
+"@bringweb3/chrome-extension-kit": patch
+---
+
+fix: resolve link trigger inconsistency

--- a/extension-files/bringweb3-sdk/bringInitContentScript.ts
+++ b/extension-files/bringweb3-sdk/bringInitContentScript.ts
@@ -125,15 +125,12 @@ const bringInitContentScript = async ({
             case 'GET_PAGE_LINKS':
                 // Only respond from the main frame, not from iframes
                 if (window !== window.top) return false;
-                console.log('[BringWeb3] GET_PAGE_LINKS: content script received request', { url: window.location.href });
                 try {
                     const links = Array.from(document.querySelectorAll('a[href]'))
                         .map(a => (a as HTMLAnchorElement).href)
                         .filter(href => href.startsWith('http'));
-                    console.log('[BringWeb3] GET_PAGE_LINKS: content script sending response', { status: 'success', linksCount: links.length, links });
                     sendResponse({ status: 'success', links });
                 } catch (error) {
-                    console.log('[BringWeb3] GET_PAGE_LINKS: content script sending response', { status: 'failed', error });
                     sendResponse({ status: 'failed', links: [] });
                 }
                 return true

--- a/extension-files/bringweb3-sdk/bringInitContentScript.ts
+++ b/extension-files/bringweb3-sdk/bringInitContentScript.ts
@@ -124,20 +124,18 @@ const bringInitContentScript = async ({
                 return true
             case 'GET_PAGE_LINKS':
                 // Only respond from the main frame, not from iframes
-                if (window !== window.top) {
-                    return false;
+                if (window !== window.top) return false;
+                console.log('[BringWeb3] GET_PAGE_LINKS: content script received request', { url: window.location.href });
+                try {
+                    const links = Array.from(document.querySelectorAll('a[href]'))
+                        .map(a => (a as HTMLAnchorElement).href)
+                        .filter(href => href.startsWith('http'));
+                    console.log('[BringWeb3] GET_PAGE_LINKS: content script sending response', { status: 'success', linksCount: links.length, links });
+                    sendResponse({ status: 'success', links });
+                } catch (error) {
+                    console.log('[BringWeb3] GET_PAGE_LINKS: content script sending response', { status: 'failed', error });
+                    sendResponse({ status: 'failed', links: [] });
                 }
-                // Force DOM to flush before querying
-                requestAnimationFrame(() => {
-                    try {
-                        const links = Array.from(document.querySelectorAll('a[href]'))
-                            .map(a => (a as HTMLAnchorElement).href)
-                            .filter(href => href.startsWith('http'));
-                        sendResponse({ status: 'success', links });
-                    } catch (error) {
-                        sendResponse({ status: 'failed', links: [] });
-                    }
-                });
                 return true
             case 'CLOSE_POPUP':
                 if (iframeEl && iframePath === request.path && getDomain(location.href) === getDomain(request.domain)) {

--- a/extension-files/bringweb3-sdk/utils/background/domainsListSearch.ts
+++ b/extension-files/bringweb3-sdk/utils/background/domainsListSearch.ts
@@ -29,6 +29,7 @@ export const searchRegexArray = async (regexArray: RegExp[], url: string, search
 
     for (let i = 0; i < regexArray.length; i++) {
         const type = domainsTypes?.[i];
+        console.log('Testing regex:', regexArray[i], 'type:', type, 'against', testStr, 'searchType:', searchType);
 
         if (searchType) {
             if (![...type].some(c => searchType.includes(c))) continue;

--- a/extension-files/bringweb3-sdk/utils/background/domainsListSearch.ts
+++ b/extension-files/bringweb3-sdk/utils/background/domainsListSearch.ts
@@ -29,7 +29,6 @@ export const searchRegexArray = async (regexArray: RegExp[], url: string, search
 
     for (let i = 0; i < regexArray.length; i++) {
         const type = domainsTypes?.[i];
-        console.log('Testing regex:', regexArray[i], 'type:', type, 'against', testStr, 'searchType:', searchType);
 
         if (searchType) {
             if (![...type].some(c => searchType.includes(c))) continue;

--- a/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
+++ b/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
@@ -211,7 +211,9 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             const quietInlineSearch = await getQuietDomain(parseUrl(tab.url), "i");
             if (quietInlineSearch.phase === 'quiet') return;
 
-            const response = await sendMessage(tabId, { action: 'GET_PAGE_LINKS' });
+            console.log('[BringWeb3] GET_PAGE_LINKS: background sending request', { tabId, url: tab.url });
+            const response = await sendMessage(tabId, { action: 'GET_PAGE_LINKS' }, undefined, 0);
+            console.log('[BringWeb3] GET_PAGE_LINKS: background received response', { tabId, status: response?.status, linksCount: response?.links?.length ?? null, links: response?.links ?? null });
 
             if (response?.status !== 'success' || !response.links?.length) return;
 

--- a/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
+++ b/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
@@ -211,9 +211,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             const quietInlineSearch = await getQuietDomain(parseUrl(tab.url), "i");
             if (quietInlineSearch.phase === 'quiet') return;
 
-            console.log('[BringWeb3] GET_PAGE_LINKS: background sending request', { tabId, url: tab.url });
             const response = await sendMessage(tabId, { action: 'GET_PAGE_LINKS' }, undefined, 0);
-            console.log('[BringWeb3] GET_PAGE_LINKS: background received response', { tabId, status: response?.status, linksCount: response?.links?.length ?? null, links: response?.links ?? null });
 
             if (response?.status !== 'success' || !response.links?.length) return;
 

--- a/extension-files/bringweb3-sdk/utils/background/sendMessage.ts
+++ b/extension-files/bringweb3-sdk/utils/background/sendMessage.ts
@@ -14,7 +14,7 @@ interface Message {
     stylesheet?: string
 }
 
-const sendMessage = (tabId: number, message: Message, maxRetries?: number): Promise<any> => {
+const sendMessage = (tabId: number, message: Message, maxRetries?: number, frameId?: number): Promise<any> => {
     maxRetries = maxRetries || 10;
     const baseDelay = 100; // 0.1 second
     const incrementalDelay = 20; // 0.02 seconds
@@ -28,7 +28,8 @@ const sendMessage = (tabId: number, message: Message, maxRetries?: number): Prom
                     return;
                 }
                 // Send message
-                chrome.tabs.sendMessage(tabId, { ...message, from: 'bringweb3' }, (response) => {
+                const options = frameId !== undefined ? { frameId } : {};
+                chrome.tabs.sendMessage(tabId, { ...message, from: 'bringweb3' }, options, (response) => {
                     if (chrome.runtime.lastError) {
                         if (attempt < maxRetries - 1) {
                             setTimeout(() => attemptSend(attempt + 1), baseDelay + incrementalDelay * attempt);


### PR DESCRIPTION
This pull request addresses an inconsistency in how link triggers are handled in the extension, specifically improving the reliability of link extraction from web pages. The main changes involve updating the messaging system to support frame targeting and making the link extraction logic more robust.

**Bug Fixes and Reliability Improvements**
- Fixed an inconsistency in link trigger behavior by ensuring the content script reliably responds to link extraction requests only from the main frame and without unnecessary `requestAnimationFrame` wrapping. (`bringInitContentScript.ts`, `.changeset/grumpy-windows-joke.md`) [[1]](diffhunk://#diff-8a4cc202575fc254f85e49a34a5a7c4fc0b9cbca6c49ba649f83c3f974c6d034R1-R5) [[2]](diffhunk://#diff-1463ceb061ef8613bfc5f661d42893123a32a13cfb1aa4708058e7724e7687f5L127-R127) [[3]](diffhunk://#diff-1463ceb061ef8613bfc5f661d42893123a32a13cfb1aa4708058e7724e7687f5L140)

**Messaging System Enhancements**
- Updated `sendMessage` to support an optional `frameId` parameter, allowing messages to be sent to a specific frame when needed. (`sendMessage.ts`) [[1]](diffhunk://#diff-fb60f2fa9cfff6b563cf3442986d7935a079edf409c9d78ad2f9cdf4b4c11588L17-R17) [[2]](diffhunk://#diff-fb60f2fa9cfff6b563cf3442986d7935a079edf409c9d78ad2f9cdf4b4c11588L31-R32)
- Modified the call to `sendMessage` for the `'GET_PAGE_LINKS'` action to explicitly set the `frameId` to `0`, ensuring the message targets the main frame. (`handleTabEvents.ts`)