### PR TITLE
fix: resizePage func and cleanup for framed mode

### DIFF
--- a/extension-files/bringweb3-sdk/.changeset/empty-windows-do.md
+++ b/extension-files/bringweb3-sdk/.changeset/empty-windows-do.md
@@ -1,0 +1,5 @@
+---
+"@bringweb3/chrome-extension-kit": patch
+---
+
+fix resizePage func and cleanup for framed mode

--- a/extension-files/bringweb3-sdk/utils/contentScript/injectFramedIframe.ts
+++ b/extension-files/bringweb3-sdk/utils/contentScript/injectFramedIframe.ts
@@ -1,13 +1,12 @@
 import insertScroller from "./insertScroller"
 import resizePage from "./resizePage"
 
-const injectFramedIframe = ({ scroller, sides, scales, resize }: FrameModeOptions) => {
+const injectFramedIframe = ({ scroller, sides, resize }: FrameModeOptions) => {
 
     insertScroller({ parent: scroller, id: 'bringweb3-scroller' });
 
     resizePage({
         sides: sides,
-        scales: scales,
         listener: resize
     });
 }

--- a/extension-files/bringweb3-sdk/utils/contentScript/resizePage.ts
+++ b/extension-files/bringweb3-sdk/utils/contentScript/resizePage.ts
@@ -1,58 +1,69 @@
 import { contentScriptCleanup } from "./cleanupManager";
 
 interface ResizePageOptions {
-    sides: [number, number, number, number] // top, right, bottom, left
-    scales: Scales,
-    listener: boolean
+    sides: [number, number, number, number]; // top, right, bottom, left
+    listener: boolean;
 }
 
-const getScale = (scale: ScaleOptions, offset: number): number => {
-    if (scale === 'w') return (window.innerWidth - offset) / window.innerWidth;
-    if (scale === 'h') return (window.innerHeight - offset) / window.innerHeight;
-    return 1;
-}
+const MANAGED_PROPS = ['width', 'height', 'transform'] as const;
 
-const sumSides = (sidesToSum: string, sides: number[]): number => {
-    return sidesToSum.split('').reduce((acc, value) => acc + (sides[parseInt(value)] ?? 0), 0);
-}
+const resizePage = ({ sides, listener }: ResizePageOptions) => {
+    const safeSides = sides.map(s => Math.max(0, s)) as [number, number, number, number];
+    const [top, right, bottom, left] = safeSides;
+    const horizontalFrame = left + right;
+    const verticalFrame = top + bottom;
 
-const resizePage = ({ sides, scales, listener }: ResizePageOptions) => {
-    // Ensure no negative sides
-    sides.forEach((side, index) => { sides[index] = Math.max(0, side) });
+    const body = document.body;
+
+    // Capture original inline values + priorities for each managed property
+    const originals = MANAGED_PROPS.map(prop => ({
+        prop,
+        value: body.style.getPropertyValue(prop),
+        priority: body.style.getPropertyPriority(prop),
+    }));
 
     const handleResize = () => {
-        const body = document.body;
-        const newScaleX = getScale(scales.x[0], sumSides(scales.x[1], sides));
-        const newScaleY = getScale(scales.y[0], sumSides(scales.y[1], sides));
-        console.table({ newScaleX, newScaleY, height: body.style.height });
+        const neededScaleX = horizontalFrame > 0
+            ? (window.innerWidth - horizontalFrame) / window.innerWidth
+            : 1;
+        const neededScaleY = verticalFrame > 0
+            ? (window.innerHeight - verticalFrame) / window.innerHeight
+            : 1;
 
-        body.style.setProperty(
-            'transform',
-            `translate(${sides[3]}px, ${sides[0]}px) scale(${newScaleX}, ${newScaleY})`,
-            'important'
-        );
-        
-        body.style.setProperty(
-            'height',
-            `calc(100vh / ${newScaleY})`,
-            'important'
-        );
+        const scale = Math.min(neededScaleX, neededScaleY);
+        const bodyWidth = (window.innerWidth - horizontalFrame) / scale;
+        const bodyHeight = (window.innerHeight - verticalFrame) / scale;
+
+        const updates: Record<typeof MANAGED_PROPS[number], string> = {
+            width: `${bodyWidth}px`,
+            height: `${bodyHeight}px`,
+            transform: `translate(${left}px, ${top}px) scale(${scale})`,
+        };
+
+        for (const prop of MANAGED_PROPS) {
+            body.style.setProperty(prop, updates[prop], 'important');
+        }
     };
 
-    // Apply initial sizing
     handleResize();
 
     if (listener) {
-        // Add resize listener
         window.addEventListener('resize', handleResize);
     }
 
-    // Return cleanup function
-    if (listener) {
-        contentScriptCleanup.add(() => {
+    contentScriptCleanup.add(() => {
+        if (listener) {
             window.removeEventListener('resize', handleResize);
-        });
-    }
-}
+        }
+
+        for (const { prop, value, priority } of originals) {
+            if (value) {
+                body.style.setProperty(prop, value, priority);
+            } else {
+                body.style.removeProperty(prop);
+            }
+        }
+    });
+};
 
 export default resizePage;

--- a/extension-files/bringweb3-sdk/utils/contentScript/resizePage.ts
+++ b/extension-files/bringweb3-sdk/utils/contentScript/resizePage.ts
@@ -13,48 +13,64 @@ const resizePage = ({ sides, listener }: ResizePageOptions) => {
     const horizontalFrame = left + right;
     const verticalFrame = top + bottom;
 
-    const body = document.body;
-
-    // Capture original inline values + priorities for each managed property
-    const originals = MANAGED_PROPS.map(prop => ({
-        prop,
-        value: body.style.getPropertyValue(prop),
-        priority: body.style.getPropertyPriority(prop),
-    }));
+    let originals: { prop: typeof MANAGED_PROPS[number]; value: string; priority: string }[] | null = null;
 
     const handleResize = () => {
-        const neededScaleX = horizontalFrame > 0
-            ? (window.innerWidth - horizontalFrame) / window.innerWidth
-            : 1;
-        const neededScaleY = verticalFrame > 0
-            ? (window.innerHeight - verticalFrame) / window.innerHeight
-            : 1;
+        const body = document.body;
+        if (!body) return;
 
-        const scale = Math.min(neededScaleX, neededScaleY);
-        const bodyWidth = (window.innerWidth - horizontalFrame) / scale;
-        const bodyHeight = (window.innerHeight - verticalFrame) / scale;
+        if (!originals) {
+            originals = MANAGED_PROPS.map(prop => ({
+                prop,
+                value: body.style.getPropertyValue(prop),
+                priority: body.style.getPropertyPriority(prop),
+            }));
+        }
 
-        const updates: Record<typeof MANAGED_PROPS[number], string> = {
-            width: `${bodyWidth}px`,
-            height: `${bodyHeight}px`,
-            transform: `translate(${left}px, ${top}px) scale(${scale})`,
-        };
+        const availableWidth = window.innerWidth - horizontalFrame;
+        const availableHeight = window.innerHeight - verticalFrame;
+
+        const updates: Record<typeof MANAGED_PROPS[number], string> = (availableWidth <= 0 || availableHeight <= 0)
+            ? {
+                width: '0px',
+                height: '0px',
+                transform: `translate(${left}px, ${top}px) scale(0)`,
+            }
+            : (() => {
+                const neededScaleX = horizontalFrame > 0 ? availableWidth / window.innerWidth : 1;
+                const neededScaleY = verticalFrame > 0 ? availableHeight / window.innerHeight : 1;
+                const scale = Math.min(neededScaleX, neededScaleY);
+
+                return {
+                    width: `${availableWidth / scale}px`,
+                    height: `${availableHeight / scale}px`,
+                    transform: `translate(${left}px, ${top}px) scale(${scale})`,
+                };
+            })();
 
         for (const prop of MANAGED_PROPS) {
             body.style.setProperty(prop, updates[prop], 'important');
         }
     };
 
-    handleResize();
+    if (document.body) {
+        handleResize();
+    } else {
+        document.addEventListener('DOMContentLoaded', handleResize, { once: true });
+    }
 
     if (listener) {
         window.addEventListener('resize', handleResize);
     }
 
     contentScriptCleanup.add(() => {
+        document.removeEventListener('DOMContentLoaded', handleResize);
         if (listener) {
             window.removeEventListener('resize', handleResize);
         }
+
+        const body = document.body;
+        if (!body || !originals) return;
 
         for (const { prop, value, priority } of originals) {
             if (value) {


### PR DESCRIPTION
This pull request focuses on fixing and cleaning up the framed mode resizing logic for the BringWeb3 Chrome extension kit. The changes simplify the `resizePage` function, improve the handling of CSS properties during resizing, and ensure proper cleanup of styles. The most important changes are:

**Framed mode resizing improvements:**

* Refactored the `resizePage` function in `resizePage.ts` to remove unnecessary scaling logic, simplify the calculation of scale and dimensions, and ensure only non-negative side values are used. Now, the function adjusts the `width`, `height`, and `transform` properties of the body element for framed mode, and restores original styles during cleanup.
* Updated the `injectFramedIframe` function in `injectFramedIframe.ts` to remove the unused `scales` parameter, aligning it with the new `resizePage` signature.

**Changelog:**

* Added a changeset entry describing the patch and the fix for the resizePage function and cleanup in framed mode.