### PR TITLE
fix: update NPM package README file

### DIFF
--- a/extension-files/bringweb3-sdk/README.md
+++ b/extension-files/bringweb3-sdk/README.md
@@ -52,7 +52,8 @@ Include this configuration inside your `manifest.json` file:
       ],
       "js": [
         "contentScript.js" // The name of the file importing the bringContentScriptInit
-      ]
+      ],
+      "all_frames": true
     }
   ],
   "host_permissions": [


### PR DESCRIPTION
This pull request makes a small configuration update to the `manifest.json` documentation for the BringWeb3 SDK. The change ensures that the content script is injected into all frames, not just the top-level frame.

* Added `"all_frames": true` to the content script configuration in the `manifest.json` example to support injection into all frames.