### PR TITLE
feat: make iframe compitable with old versions back to v1.5.0

### DIFF
--- a/iframe-frontend/src/pages/Activated/Activated.tsx
+++ b/iframe-frontend/src/pages/Activated/Activated.tsx
@@ -13,7 +13,7 @@ import { getIframeStyle } from '../../utils/iframeStyles'
 import { ENV, ACTIVATE_QUIET_TIME, OB_ACTIVATE_QUIET_TIME } from '../../config'
 
 const Activated = () => {
-    const { topGeneralTermsUrl, retailerTermsUrl, generalTermsUrl, platformName, tokenSymbol, isOfferBar, iframeStyle: themeIframeStyle } = useRouteLoaderData('root') as ActivatedData & { iframeStyle?: Record<string, string> }
+    const { version, topGeneralTermsUrl, retailerTermsUrl, generalTermsUrl, platformName, tokenSymbol, isOfferBar, iframeStyle: themeIframeStyle } = useRouteLoaderData('root') as ActivatedData & { iframeStyle?: Record<string, string> }
     const { walletAddress } = useWalletAddress()
     const [markdownContent, setMarkdownContent] = useState('')
     // const [loading, setLoading] = useState(true)
@@ -21,7 +21,7 @@ const Activated = () => {
     useEffect(() => {
         const controller = new AbortController()
 
-        sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('popup', platformName, themeIframeStyle) })
+        sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('popup', platformName, version, themeIframeStyle) })
 
         const loadAllMarkdown = async () => {
             try {
@@ -65,8 +65,8 @@ const Activated = () => {
                 <p id="activated-text" className={styles.p}>Reward approval may take up to 48 hours.</p>
                 <div id="activated-backed-by" className={styles.backed_by}>Backed by {toCapital(platformName)} Wallet</div>
             </div>
-            <Markdown 
-                className={styles.markdown} 
+            <Markdown
+                className={styles.markdown}
                 rehypePlugins={[rehypeRaw]}
                 components={{
                     a: ({ href, children, ...props }) => {

--- a/iframe-frontend/src/pages/Framed/Framed.tsx
+++ b/iframe-frontend/src/pages/Framed/Framed.tsx
@@ -112,11 +112,11 @@ const Framed = () => {
             details: name
         })
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [cryptoSymbols, domain, searchEngineDomain, flowId, name, displayName, platformName, retailerId, sendGaEvent, url, userId, version, walletAddress, networkUrl, isOfferBar, offerBarSearch, searchTermPattern])
 
     useEffect(() => {
-        sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('offerbarFramed', platformName, themeIframeStyle) })
+        sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('offerbarFramed', platformName, version, themeIframeStyle) })
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
@@ -125,9 +125,9 @@ const Framed = () => {
             {/* Top bar — fixed 71px strip at top of viewport */}
             <div id="tb-container" className={styles.tbBar}>
                 {showOptout ? (
-                    <Optout 
-                        closeFn={() => setShowOptout(false)} 
-                        onOptOut={() => setIsOptedOut(true)} 
+                    <Optout
+                        closeFn={() => setShowOptout(false)}
+                        onOptOut={() => setIsOptedOut(true)}
                         onConfirmClose={close}
                     />
                 ) : (

--- a/iframe-frontend/src/pages/Home/Home.tsx
+++ b/iframe-frontend/src/pages/Home/Home.tsx
@@ -13,7 +13,7 @@ const Home = () => {
   const { version, variant, platformName, domain, iframeStyle: themeIframeStyle } = useRouteLoaderData('root') as LoaderData
 
   useEffect(() => {
-    sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('popup', platformName, themeIframeStyle) })
+    sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('popup', platformName, version, themeIframeStyle) })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/iframe-frontend/src/pages/Notification/Notification.tsx
+++ b/iframe-frontend/src/pages/Notification/Notification.tsx
@@ -9,6 +9,8 @@ import toCaseString from '../../utils/toCaseString'
 import useTimeout from '../../hooks/useTimeout'
 import { useWalletAddress } from '../../hooks/useWalletAddress'
 
+const PAIRING_DIMS = { width: '699px', height: '70px' }
+
 const formatDate = (str: number): string => {
     const date = new Date(str);
     const formatted = date.toLocaleDateString('en-US', {
@@ -90,10 +92,11 @@ interface Notification {
     expiredAt: number | null
     isRemindingPeriod: boolean
     promptPairing: boolean
+    version: string
 }
 
 const Notification = () => {
-    const { platformName, textMode, cashbackUrl, new: _new, eligible, total, expiredAt, promptPairing, iframeStyle: themeIframeStyle } = useRouteLoaderData('root') as Notification & { iframeStyle?: Record<string, string> }
+    const { platformName, textMode, cashbackUrl, new: _new, eligible, total, expiredAt, promptPairing, iframeStyle: themeIframeStyle, version } = useRouteLoaderData('root') as Notification & { iframeStyle?: Record<string, string> }
     const { walletAddress } = useWalletAddress()
     const ctaText = !promptPairing ? 'Details' : eligible ? 'Claim' : 'Connect'
     const isExtraBtn = !_new
@@ -103,16 +106,16 @@ const Notification = () => {
     })
 
     useEffect(() => {
-        const style = getIframeStyle('notification', platformName, themeIframeStyle)
-
-        if (promptPairing) {
-            style.iframe.width = '699px';
-            style.iframe.height = '70px';
-        }
+        const base = getIframeStyle('notification', platformName, version, themeIframeStyle)
+        const style = !promptPairing
+            ? base
+            : 'iframe' in base && typeof base.iframe === 'object'
+                ? { ...base, iframe: { ...base.iframe, ...PAIRING_DIMS } }
+                : { ...base, ...PAIRING_DIMS }
 
         sendMessage({ action: ACTIONS.OPEN, style })
 
-    }, [platformName, promptPairing, themeIframeStyle])
+    }, [platformName, promptPairing, themeIframeStyle, version])
 
     useEffect(() => {
         start()

--- a/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Offerbar.tsx
@@ -109,7 +109,7 @@ const Offerbar = () => {
   }, [cryptoSymbols, domain, searchEngineDomain, flowId, name, platformName, retailerId, sendGaEvent, url, userId, version, walletAddress, networkUrl, isOfferBar, offerBarSearch, offerBarPageUrl, searchTermPattern])
 
   useEffect(() => {
-    sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('offerbar', platformName, themeIframeStyle) })
+    sendMessage({ action: ACTIONS.OPEN, style: getIframeStyle('offerbar', platformName, version, themeIframeStyle) })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/iframe-frontend/src/types.d.ts
+++ b/iframe-frontend/src/types.d.ts
@@ -75,6 +75,7 @@ declare global {
     interface ActivatedData extends Info {
         tokenSymbol: string
         iconsPath: string
+        version: string
     }
 
     interface Message {

--- a/iframe-frontend/src/utils/iframeStyles.ts
+++ b/iframe-frontend/src/utils/iframeStyles.ts
@@ -118,18 +118,15 @@ export const getIframeStyle = (
 ): { [key: string]: { [key: string]: string } } | { [key: string]: string } => {
     const styles = styleMap[page]
     const baseIframeStyle = styles[platformName.toLowerCase()] || styles['default']
-    if (!themeIframeStyle) return baseIframeStyle
-    const versionComparison = compareVersions(version, '1.6.0')
-    if (versionComparison === -1) {
-        return {
-            ...baseIframeStyle.iframe,
-            ...themeIframeStyle
-        }
+    const isLegacy = compareVersions(version, '1.6.0') === -1
+
+    if (isLegacy) {
+        return themeIframeStyle
+            ? { ...baseIframeStyle.iframe, ...themeIframeStyle }
+            : baseIframeStyle.iframe
     }
-    return {
-        iframe: {
-            ...baseIframeStyle.iframe,
-            ...themeIframeStyle
-        }
-    }
+
+    return themeIframeStyle
+        ? { iframe: { ...baseIframeStyle.iframe, ...themeIframeStyle } }
+        : baseIframeStyle
 }

--- a/iframe-frontend/src/utils/iframeStyles.ts
+++ b/iframe-frontend/src/utils/iframeStyles.ts
@@ -1,3 +1,4 @@
+import compareVersions from "./compareVersions"
 
 interface Styles {
     [key: string]: { [key: string]: { [key: string]: string } }
@@ -112,11 +113,21 @@ const styleMap: Record<IframePage, Styles> = {
 export const getIframeStyle = (
     page: IframePage,
     platformName: string,
-    themeIframeStyle?: Record<string, string>
-): { [key: string]: { [key: string]: string } } => {
+    version: string,
+    themeIframeStyle?: Record<string, string>,
+): { [key: string]: { [key: string]: string } } | { [key: string]: string } => {
     const styles = styleMap[page]
     const baseIframeStyle = styles[platformName.toLowerCase()] || styles['default']
     if (!themeIframeStyle) return baseIframeStyle
+    console.log('current version:', version)
+    const versionComparison = compareVersions(version, '1.6.0')
+    console.log('Version comparison result:', versionComparison)
+    if (versionComparison === -1) {
+        return {
+            ...baseIframeStyle.iframe,
+            ...themeIframeStyle
+        }
+    }
     return {
         iframe: {
             ...baseIframeStyle.iframe,

--- a/iframe-frontend/src/utils/iframeStyles.ts
+++ b/iframe-frontend/src/utils/iframeStyles.ts
@@ -119,9 +119,7 @@ export const getIframeStyle = (
     const styles = styleMap[page]
     const baseIframeStyle = styles[platformName.toLowerCase()] || styles['default']
     if (!themeIframeStyle) return baseIframeStyle
-    console.log('current version:', version)
     const versionComparison = compareVersions(version, '1.6.0')
-    console.log('Version comparison result:', versionComparison)
     if (versionComparison === -1) {
         return {
             ...baseIframeStyle.iframe,


### PR DESCRIPTION
This pull request updates the way iframe styles are determined and applied throughout the frontend, making the logic version-aware and ensuring compatibility with older versions. The most important changes include passing the `version` parameter to the `getIframeStyle` utility, updating the utility to handle version-based logic, and improving the handling of pairing notification dimensions.

**Version-aware iframe styling:**

* The `version` parameter is now passed to the `getIframeStyle` function in all relevant components (`Home`, `Activated`, `Offerbar`, `Framed`, and `Notification`), ensuring that style logic can vary based on the app version. [[1]](diffhunk://#diff-32d377f8ebc1e46f684a9e198689268a9f26fd4a9b40f4501360d39799bf2643L16-R16) [[2]](diffhunk://#diff-689c0e2faea2acea7ad3688b3ad2cfd1d71e56a65514fb895a36056ed5fcdf52L16-R24) [[3]](diffhunk://#diff-ac9b0835e0c572bf0bccf31ced28b451f32eb298b2a6dcc4f354e5126b8748e8L112-R112) [[4]](diffhunk://#diff-e8edbdb1853b33265b4ba12db4aa027d30f09855a02bb27b09e818a02884e61bL119-R119) [[5]](diffhunk://#diff-3d152a080f086e32ecaa57d0fd6a7c5ce67c69b23a15d53f24916674093b825aR95-R99)
* The `getIframeStyle` utility (`iframeStyles.ts`) has been updated to accept the `version` parameter and use the new `compareVersions` helper to determine if the provided version is older than `1.6.0`. For versions older than `1.6.0`, the merged style is returned in a legacy format for backward compatibility. [[1]](diffhunk://#diff-a1449ef613e783a991e193c070ca6d276f740691856564a91b88dcce56444c63R1) [[2]](diffhunk://#diff-a1449ef613e783a991e193c070ca6d276f740691856564a91b88dcce56444c63L115-R130)

**Notification component improvements:**

* The notification component's style logic now uses the version-aware `getIframeStyle` and improves handling of the pairing prompt by conditionally merging dimensions for the iframe. This ensures correct sizing for pairing notifications across versions. [[1]](diffhunk://#diff-3d152a080f086e32ecaa57d0fd6a7c5ce67c69b23a15d53f24916674093b825aR12-R13) [[2]](diffhunk://#diff-3d152a080f086e32ecaa57d0fd6a7c5ce67c69b23a15d53f24916674093b825aL106-R118)

These updates improve maintainability and ensure consistent styling behavior across different app versions.