### PR TITLE
fix: force NODE_ENV=development for yarn install in iframe-only mode

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -192,11 +192,11 @@ fi
 # Start build timer
 BUILD_START_TIME=$(date +%s)
 if [ "$IFRAME_ONLY" = true ]; then
-    # Install iframe-frontend dependencies only
+    # Install iframe-frontend dependencies (including devDependencies for build tools)
     echo "========================================"
     echo "Installing iframe-frontend dependencies..."
     echo "========================================"
-    yarn install --cwd iframe-frontend --frozen-lockfile
+    NODE_ENV=development yarn install --cwd iframe-frontend --frozen-lockfile
     echo "✓ Dependencies installed"
     echo ""
 elif [ "$IFRAME_ONLY" = false ]; then


### PR DESCRIPTION
NODE_ENV=production (set by workflow) causes yarn to skip devDependencies, which includes vite, typescript, and type definitions needed for the build.