### PR TITLE
feat: update publish workflow to use OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write          # NEW - required for OIDC → npm
 
 defaults:
   run:
@@ -20,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Debug directory structure
-        run: |
-          pwd
-          ls -la
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'yarn'
           cache-dependency-path: 'extension-files/bringweb3-sdk/yarn.lock'
+          registry-url: 'https://registry.npmjs.org'   # NEW - ensures .npmrc points at npmjs
+
+      - name: Upgrade npm to OIDC-capable version
+        run: npm install -g npm@latest   # NEW - need >= 11.5.1; lts/* ships with npm 10.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -43,4 +44,3 @@ jobs:
           title: "chore(release): version SDK package"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/publish.yml` to support publishing to npm using OpenID Connect (OIDC) authentication, which enhances security and removes the need for a long-lived `NPM_TOKEN`. The changes also streamline the workflow by removing unnecessary debugging steps and ensuring compatibility with OIDC requirements.

**OIDC Authentication for npm Publishing:**

* Added `id-token: write` permission to enable OIDC authentication for npm publishing.
* Ensured `.npmrc` points to the npm registry by setting `registry-url` in the `setup-node` action.
* Upgraded npm to the latest version (>=11.5.1) to ensure OIDC support, as the default LTS Node.js image ships with npm 10.x.
* Removed the use of the `NPM_TOKEN` secret from the environment, as it is no longer needed with OIDC.

**Workflow Cleanup:**

* Removed the debug step that printed the directory structure, streamlining the workflow.