### PR TITLE
fix: cap specific-site forever-optout at 60 days, mark type 'a'

### DIFF
--- a/iframe-frontend/src/components/OptOut/OptOut.tsx
+++ b/iframe-frontend/src/components/OptOut/OptOut.tsx
@@ -105,8 +105,7 @@ const OptOut = ({ onClose, onOpted }: Props) => {
 
         // Temp fix: forever-optout for a specific website sends time=999999999999999, whose
         // range exceeds the 60-day cleanup cap and gets wiped immediately. Send exactly 60 days
-        // and mark type with 'a' so the backend can later reset these to true forever. Only the
-        // specific-site path (OPT_OUT_SPECIFIC) is affected; all-websites forever stays forever.
+        // and mark type with 'a'.
         const isForeverSpecific = !websites.value && duration.label === 'forever'
 
         const event = {
@@ -114,6 +113,7 @@ const OptOut = ({ onClose, onOpted }: Props) => {
             time: isForeverSpecific ? 60 * 24 * 60 * 60 * 1000 : +duration.value,
             domain,
             key: dict[duration.label as keyof typeof dict],
+            //Temp fix: forever+specific only: this path normally sends no type (defaults to 'kds')
             ...(isForeverSpecific ? { type: ['kdsa'], isRegex: [false] } : {})
         }
 

--- a/iframe-frontend/src/components/OptOut/OptOut.tsx
+++ b/iframe-frontend/src/components/OptOut/OptOut.tsx
@@ -103,11 +103,18 @@ const OptOut = ({ onClose, onOpted }: Props) => {
         
         const { websites, duration } = selection
 
+        // Temp fix: forever-optout for a specific website sends time=999999999999999, whose
+        // range exceeds the 60-day cleanup cap and gets wiped immediately. Send exactly 60 days
+        // and mark type with 'a' so the backend can later reset these to true forever. Only the
+        // specific-site path (OPT_OUT_SPECIFIC) is affected; all-websites forever stays forever.
+        const isForeverSpecific = !websites.value && duration.label === 'forever'
+
         const event = {
             action: websites.value ? ACTIONS.OPT_OUT : ACTIONS.OPT_OUT_SPECIFIC,
-            time: +duration.value,
+            time: isForeverSpecific ? 60 * 24 * 60 * 60 * 1000 : +duration.value,
             domain,
-            key: dict[duration.label as keyof typeof dict]
+            key: dict[duration.label as keyof typeof dict],
+            ...(isForeverSpecific ? { type: ['kdsa'], isRegex: [false] } : {})
         }
 
         sendMessage(event)

--- a/iframe-frontend/src/pages/Framed/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Framed/Optout/Optout.tsx
@@ -29,12 +29,16 @@ const Optout = ({ closeFn, onOptOut, onConfirmClose }: Props) => {
     const [selectedOption, setSelectedOption] = useState(durationOptions[0]) // 24 hours by default
 
     const handleOptOut = (duration: typeof durationOptions[0]) => {
+        // Temp fix: "forever" sends time=999999999999999, whose range exceeds the 60-day
+        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'
+        // so the backend can later reset these to true forever.
+        const isForever = duration.label === 'forever'
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,
             domain: ['google.com'],
-            type: ["kdsi"],
+            type: isForever ? ["kdsia"] : ["kdsi"],
             isRegex: [false],
-            time: +duration.value,
+            time: isForever ? 60 * 24 * 60 * 60 * 1000 : +duration.value,
             key: dict[duration.label as keyof typeof dict]
         }
 

--- a/iframe-frontend/src/pages/Framed/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Framed/Optout/Optout.tsx
@@ -30,8 +30,7 @@ const Optout = ({ closeFn, onOptOut, onConfirmClose }: Props) => {
 
     const handleOptOut = (duration: typeof durationOptions[0]) => {
         // Temp fix: "forever" sends time=999999999999999, whose range exceeds the 60-day
-        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'
-        // so the backend can later reset these to true forever.
+        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'.
         const isForever = duration.label === 'forever'
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,

--- a/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
@@ -29,12 +29,16 @@ const Optout = ({ closeFn, onOptOut }: Props) => {
 
 
     const handleOptOut = (duration: typeof durationOptions[0]) => {
+        // Temp fix: "forever" sends time=999999999999999, whose range exceeds the 60-day
+        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'
+        // so the backend can later reset these to true forever.
+        const isForever = duration.label === 'forever'
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,
             domain: ['google.com'],
-            type: ["kdsi"],
+            type: isForever ? ["kdsia"] : ["kdsi"],
             isRegex: [false],
-            time: +duration.value,
+            time: isForever ? 60 * 24 * 60 * 60 * 1000 : +duration.value,
             key: dict[duration.label as keyof typeof dict]
         }
 

--- a/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
@@ -30,8 +30,7 @@ const Optout = ({ closeFn, onOptOut }: Props) => {
 
     const handleOptOut = (duration: typeof durationOptions[0]) => {
         // Temp fix: "forever" sends time=999999999999999, whose range exceeds the 60-day
-        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'
-        // so the backend can later reset these to true forever.
+        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'.
         const isForever = duration.label === 'forever'
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,


### PR DESCRIPTION
Forever-optout for a specific site sent time=999999999999999, whose stored range exceeds the 60-day cleanup cap (cleanupDomains/getQuietDomain) and was deleted on first run, so offers kept showing.

Temp client fix until the SDK drops the 60-day cleanup: send exactly 60 days and append marker 'a' to the quiet-domain type so the backend can later reset these to true forever. Marker appended (not replacing) to keep k/d/s/i char-based matching intact. All-websites forever unchanged.