### PR TITLE
fix: remove 60-day cap on per-site opt-out duration

### DIFF
--- a/extension-files/bringweb3-sdk/.changeset/green-radios-tie.md
+++ b/extension-files/bringweb3-sdk/.changeset/green-radios-tie.md
@@ -1,0 +1,5 @@
+---
+"@bringweb3/chrome-extension-kit": patch
+---
+
+Remove the legacy 60-day cap on per-site opt-out duration so "forever" opt-outs persist. Expired quiet-domain records are now pruned only when adding records, never on read.

--- a/extension-files/bringweb3-sdk/tests/cleanupDomains.test.ts
+++ b/extension-files/bringweb3-sdk/tests/cleanupDomains.test.ts
@@ -1,0 +1,23 @@
+import { cleanupQuietDomains } from '../utils/background/cleanupDomains'
+import { describe, it, expect } from 'vitest'
+
+const entry = (domain: string, start: number, end: number) => ({
+    domain,
+    time: [start, end] as [number, number],
+    phase: 'quiet' as const
+})
+
+describe('cleanupQuietDomains', () => {
+    it('keeps a forever entry (no 60-day cap)', () => {
+        const now = Date.now()
+        const forever = entry('forever.com', now, now + 999999999999999)
+        expect(cleanupQuietDomains([forever])).toEqual([forever])
+    })
+
+    it('drops naturally expired entries', () => {
+        const now = Date.now()
+        const expired = entry('expired.com', now - 2000, now - 1000)
+        const active = entry('active.com', now, now + 1000)
+        expect(cleanupQuietDomains([expired, active])).toEqual([active])
+    })
+})

--- a/extension-files/bringweb3-sdk/utils/background/cleanupDomains.ts
+++ b/extension-files/bringweb3-sdk/utils/background/cleanupDomains.ts
@@ -1,4 +1,3 @@
-import { DAY_MS } from "../constants"
 import { isMsRangeActive } from "./timestampRange"
 
 interface QuietDomainEntry {
@@ -16,10 +15,9 @@ interface QuietDomainEntry {
 
 export const cleanupQuietDomains = (quietDomains: any, maxLength: number = 50) => {
     const now = Date.now()
-    const maxRange = { maxRange: 60 * DAY_MS }
-    
+
     const validEntries = quietDomains.filter((entry: QuietDomainEntry) => {
-        return isMsRangeActive(entry.time, now, maxRange)
+        return isMsRangeActive(entry.time, now)
     })
     
     if (validEntries.length > maxLength) {

--- a/extension-files/bringweb3-sdk/utils/background/getQuietDomain.ts
+++ b/extension-files/bringweb3-sdk/utils/background/getQuietDomain.ts
@@ -1,4 +1,3 @@
-import { DAY_MS } from "../constants"
 import storage from "../storage/storage"
 import { isMsRangeActive } from "./timestampRange"
 import { searchSingle } from "./domainsListSearch"
@@ -28,17 +27,11 @@ const getQuietDomain = async (url: string, type?: string): Promise<Response> => 
         if (type && !type.split('').some(t => entry.type?.includes(t))) continue
 
         if (searchSingle(entry.domain, url, entry.regex)) {
-
-            const { time } = entry
-            const isActive = isMsRangeActive(time, undefined, { maxRange: 60 * DAY_MS })
-            
-            if (!isActive) {
-                quietDomains.splice(i, 1)
-                await storage.set('quietDomains', quietDomains)
-            } else {
-                phase = entry.phase || 'quiet'
-                payload = entry.payload || {}
-            }
+            // Expired entries are only pruned in addQuietDomain; skip them here so a
+            // stale record doesn't shadow a valid one behind it.
+            if (!isMsRangeActive(entry.time)) continue
+            phase = entry.phase || 'quiet'
+            payload = entry.payload || {}
             break
         }
     }

--- a/extension-files/bringweb3-sdk/utils/background/timestampRange.ts
+++ b/extension-files/bringweb3-sdk/utils/background/timestampRange.ts
@@ -9,11 +9,7 @@ export const isValidTimestampRange = (timestampRange: unknown): boolean => {
     return typeof start === 'number' && typeof end === 'number' && start <= end;
 }
 
-interface Config {
-    maxRange?: number; // Maximum allowed range in milliseconds
-}
-
-export const isMsRangeExpired = (timestampRange: [number, number], now?: number, config?: Config): boolean => {
+export const isMsRangeExpired = (timestampRange: [number, number], now?: number): boolean => {
     if (!isValidTimestampRange(timestampRange)) {
         return true; // Invalid range, consider it expired
     }
@@ -24,15 +20,9 @@ export const isMsRangeExpired = (timestampRange: [number, number], now?: number,
     // Check if the current time is outside the range
     if (now < start || now > end) return true; // Range is expired
 
-    if (config?.maxRange !== undefined) {
-        const range = end - start;
-        if (range > config.maxRange) {
-            return true; // Range exceeds the maximum allowed range
-        }
-    }
     return false; // Range is valid and not expired
 }
 
-export const isMsRangeActive = (timestampRange: [number, number], now?: number, config?: Config): boolean => {
-    return !isMsRangeExpired(timestampRange, now, config);
+export const isMsRangeActive = (timestampRange: [number, number], now?: number): boolean => {
+    return !isMsRangeExpired(timestampRange, now);
 }

--- a/iframe-frontend/src/components/OptOut/OptOut.tsx
+++ b/iframe-frontend/src/components/OptOut/OptOut.tsx
@@ -5,6 +5,7 @@ import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics';
 import { useRouteLoaderData } from 'react-router-dom';
 import toCapital from '../../utils/toCapital';
 import toCaseString from '../../utils/toCaseString';
+import isLegacyCapSdk from '../../utils/isLegacyCapSdk';
 
 interface Option {
     label: string
@@ -79,7 +80,7 @@ interface Props {
 }
 
 const OptOut = ({ onClose, onOpted }: Props) => {
-    const { cryptoSymbols, platformName, displayPlatformName, textMode, domain, name } = useRouteLoaderData('root') as LoaderData
+    const { cryptoSymbols, platformName, displayPlatformName, textMode, domain, name, version } = useRouteLoaderData('root') as LoaderData
     const { sendGaEvent } = useGoogleAnalytics()
     const [isOpted, setIsOpted] = useState(false)  
     
@@ -103,17 +104,14 @@ const OptOut = ({ onClose, onOpted }: Props) => {
         
         const { websites, duration } = selection
 
-        // Temp fix: forever-optout for a specific website sends time=999999999999999, whose
-        // range exceeds the 60-day cleanup cap and gets wiped immediately. Send exactly 60 days
-        // and mark type with 'a'.
-        const isForeverSpecific = !websites.value && duration.label === 'forever'
+        // SDK < 1.8.0: clamp forever to 60d + tag 'a' - see isLegacyCapSdk
+        const isForeverSpecific = !websites.value && duration.label === 'forever' && isLegacyCapSdk(version)
 
         const event = {
             action: websites.value ? ACTIONS.OPT_OUT : ACTIONS.OPT_OUT_SPECIFIC,
             time: isForeverSpecific ? 60 * 24 * 60 * 60 * 1000 : +duration.value,
             domain,
             key: dict[duration.label as keyof typeof dict],
-            //Temp fix: forever+specific only: this path normally sends no type (defaults to 'kds')
             ...(isForeverSpecific ? { type: ['kdsa'], isRegex: [false] } : {})
         }
 

--- a/iframe-frontend/src/pages/Framed/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Framed/Optout/Optout.tsx
@@ -2,6 +2,7 @@ import { useRouteLoaderData } from 'react-router-dom'
 import { useState } from 'react'
 import { sendMessage, ACTIONS } from '../../../utils/sendMessage'
 import { useGoogleAnalytics } from '../../../hooks/useGoogleAnalytics'
+import isLegacyCapSdk from '../../../utils/isLegacyCapSdk'
 import styles from './styles.module.css'
 
 interface Props {
@@ -23,15 +24,14 @@ const dict = {
 }
 
 const Optout = ({ closeFn, onOptOut, onConfirmClose }: Props) => {
-    const { domain, name } = useRouteLoaderData('root') as LoaderData
+    const { domain, name, version } = useRouteLoaderData('root') as LoaderData
     const { sendGaEvent } = useGoogleAnalytics()
     const [isOpted, setIsOpted] = useState(false)
     const [selectedOption, setSelectedOption] = useState(durationOptions[0]) // 24 hours by default
 
     const handleOptOut = (duration: typeof durationOptions[0]) => {
-        // Temp fix: "forever" sends time=999999999999999, whose range exceeds the 60-day
-        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'.
-        const isForever = duration.label === 'forever'
+        // SDK < 1.8.0: clamp forever to 60d + tag 'a' - see isLegacyCapSdk
+        const isForever = duration.label === 'forever' && isLegacyCapSdk(version)
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,
             domain: ['google.com'],

--- a/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
+++ b/iframe-frontend/src/pages/Offerbar/Optout/Optout.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import toCaseString from '../../../utils/toCaseString'
 import { sendMessage, ACTIONS } from '../../../utils/sendMessage'
 import { useGoogleAnalytics } from '../../../hooks/useGoogleAnalytics'
+import isLegacyCapSdk from '../../../utils/isLegacyCapSdk'
 import styles from './styles.module.css'
 
 interface Props {
@@ -23,15 +24,14 @@ const dict = {
 }
 
 const Optout = ({ closeFn, onOptOut }: Props) => {
-    const { textMode, domain, name, platformName } = useRouteLoaderData('root') as LoaderData
+    const { textMode, domain, name, platformName, version } = useRouteLoaderData('root') as LoaderData
     const { sendGaEvent } = useGoogleAnalytics()
     const [isOpted, setIsOpted] = useState(false)
 
 
     const handleOptOut = (duration: typeof durationOptions[0]) => {
-        // Temp fix: "forever" sends time=999999999999999, whose range exceeds the 60-day
-        // cleanup cap and gets wiped immediately. Send exactly 60 days and mark type with 'a'.
-        const isForever = duration.label === 'forever'
+        // SDK < 1.8.0: clamp forever to 60d + tag 'a' - see isLegacyCapSdk
+        const isForever = duration.label === 'forever' && isLegacyCapSdk(version)
         const event: Message = {
             action: ACTIONS.OPT_OUT_SPECIFIC,
             domain: ['google.com'],

--- a/iframe-frontend/src/utils/isLegacyCapSdk.ts
+++ b/iframe-frontend/src/utils/isLegacyCapSdk.ts
@@ -1,0 +1,8 @@
+import compareVersions from './compareVersions'
+
+// SDKs below 1.8.0 wipe quiet-domain records whose range exceeds 60 days.
+// For those, "forever" per-site opt-out is clamped to 60 days and tagged type 'a'
+// so the backend can later migrate the records to truly forever.
+const isLegacyCapSdk = (version: string) => compareVersions(version, '1.8.0') === -1
+
+export default isLegacyCapSdk


### PR DESCRIPTION
## Summary

Removes the legacy 60-day cap on per-site opt-out duration. The cap caused "forever" per-site opt-outs to be treated as expired and deleted, so the banner reappeared for users who opted out forever on a specific website . Global opt-out was never capped and is unaffected.

## Changes

**SDK (`@bringweb3/chrome-extension-kit`)**
- Removed the `60 * DAY_MS` max-range check from `getQuietDomain` and `cleanupQuietDomains` — no code path clamps per-site opt-out duration anymore.
- `getQuietDomain` no longer deletes records on read; it's a pure read that skips stale entries. Pruning of expired records happens exclusively in `addQuietDomain` (via `cleanupQuietDomains`).
- Removed the now-dead `maxRange` config from `timestampRange.ts`.
- Added `tests/cleanupDomains.test.ts` covering that a forever-range entry survives cleanup and expired entries are dropped.
- Added a patch changeset (release will combine with the pending `followups` minor changeset → **1.8.0**).

**Iframe (`iframe-frontend`)**
- New `isLegacyCapSdk(version)` util: `true` when the extension's SDK version (`v` query param) is below 1.8.0.
- The hotfix (clamp "forever" to 60 days + tag type with `'a'`) in `components/OptOut`, `pages/Offerbar/Optout`, and `pages/Framed/Optout` now applies **only** for legacy SDKs. On SDK ≥ 1.8.0 the true forever value is sent and persists as-is.

## Rollout / notes

- Partners must install the patched package for the real fix to take effect; the iframe keeps the clamped behavior for older installed versions.
- Existing records tagged `'a'` ("forever specific") get migrated to truly forever in the backend — separate work, no client-side migration.
- Backend still applies its own 60-day cap in `isInQuietPeriod` and can push replacement `quietDomains` lists; that removal is also backend-side work.