### PR TITLE
chore: add debug logging across popup-decision flow

### DIFF
--- a/extension-files/bringweb3-sdk/bringInitContentScript.ts
+++ b/extension-files/bringweb3-sdk/bringInitContentScript.ts
@@ -130,32 +130,40 @@ const bringInitContentScript = async ({
                     const links = Array.from(document.querySelectorAll('a[href]'))
                         .map(a => (a as HTMLAnchorElement).href)
                         .filter(href => href.startsWith('http'));
+                    logger.debug(`[content] Scraped page links for inline search`, { count: links.length });
                     sendResponse({ status: 'success', links });
                 } catch (error) {
+                    logger.error(`[content] Page-links scrape failed`, error);
                     sendResponse({ status: 'failed', links: [] });
                 }
                 return true
             case 'CLOSE_POPUP':
                 if (iframeEl && iframePath === request.path && getDomain(location.href) === getDomain(request.domain)) {
+                    logger.info(`[content] Closing popup`, { domain: request.domain, path: request.path });
                     removeElements();
                     sendResponse({ status: 'success', message: 'Popup closed', location: window.document.location.href, flowId })
                 } else {
+                    logger.debug(`[content] Ignored close request — domain mismatch or popup not open`, { domain: request.domain, path: request.path });
                     sendResponse({ status: 'failed', message: 'Domain mismatch or iframe not open' })
                 }
                 return true
             case 'INJECT':
                 try {
+                    logger.info(`[content] Open-popup request received`, { domain: request.domain, page: request.page, isSpaNavigation: request.isSpaNavigation, flowId: request.flowId });
                     const { referrer } = document
                     const referrers = request.referrers || []
 
                     if (getDomain(location.href) !== getDomain(request.domain)) {
+                        logger.info(`[content] No popup — page domain already changed`, { current: getDomain(location.href), expected: getDomain(request.domain) });
                         sendResponse({ status: 'failed', message: 'Domain already changed' });
                         return true
                     } else if (isIframeOpen) {
                         // On SPA navigations, pagehide doesn't fire, so close the old popup before injecting.
                         if (request.isSpaNavigation) {
+                            logger.debug(`[content] SPA navigation — closing previous popup before re-injecting`);
                             removeElements();
                         } else {
+                            logger.info(`[content] No popup — popup already open`);
                             sendResponse({ status: 'failed', message: 'iframe already open' });
                             return true
                         }
@@ -164,6 +172,7 @@ const bringInitContentScript = async ({
                     const isReferrer = !!referrer && referrers.includes(getDomain(referrer))
 
                     if (isReferrer && request.page === '') {
+                        logger.info(`[content] No popup — already activated by referrer`, { referrer: getDomain(referrer) });
                         sendResponse({ status: 'failed', message: `already activated by ${getDomain(referrer)}`, action: 'activate' });
                         return true
                     }
@@ -188,9 +197,11 @@ const bringInitContentScript = async ({
                     isIframeOpen = true
                     iframePath = `/${request.page || ''}`
                     flowId = request.flowId
+                    logger.info(`[content] Popup shown (iframe injected)`, { domain: request.domain, page: request.page, flowId });
                     sendResponse({ status: 'success' });
                     return true
                 } catch (error) {
+                    logger.error(`[content] Open-popup request failed`, error);
                     if (error instanceof Error) {
                         sendResponse({ status: 'failed', message: error.message });
                     } else {

--- a/extension-files/bringweb3-sdk/utils/background/activate.ts
+++ b/extension-files/bringweb3-sdk/utils/background/activate.ts
@@ -5,11 +5,14 @@ import getCashbackUrl from "./getCashbackUrl";
 import isWhitelisted from "./isWhitelisted";
 import { DAY_MS } from "../constants";
 import closeAllPopups from "./closeAllPopups";
+import { logger } from "../logger";
 
 const handleActivate = async (domain: string, extensionId: string, source: string, cashbackPagePath: string | undefined, showNotifications: boolean, type: string, isRegex:boolean, time?: number, tabId?: number, iframeUrl?: string, token?: string, flowId?: string, redirectUrl?: string) => {
     const now = Date.now();
 
     const isSameExtension = extensionId === chrome.runtime.id
+
+    logger.info(`[activate] Activating cashback`, { domain, source, tabId, sameExtension: isSameExtension, flowId });
 
     if (isSameExtension) {
         const storageOps = [storage.set('lastActivation', now)];

--- a/extension-files/bringweb3-sdk/utils/background/applyQuietDomainsUpdate.ts
+++ b/extension-files/bringweb3-sdk/utils/background/applyQuietDomainsUpdate.ts
@@ -1,4 +1,5 @@
 import storage from "../storage/storage"
+import { logger } from "../logger"
 
 // Server-driven quiet-domains sync. The backend hands back the full list when it
 // has mutated it (e.g. added/removed an entry as part of activation or a followup
@@ -6,7 +7,10 @@ import storage from "../storage/storage"
 // normalized to absolute `[now, now+time]` ranges so storage only ever holds
 // ms-ranges.
 const applyQuietDomainsUpdate = async (quietDomains: any[]) => {
-    if (!Array.isArray(quietDomains)) return
+    if (!Array.isArray(quietDomains)) {
+        logger.debug(`[quiet-sync] Skipped — server sent no quiet-domains array`)
+        return
+    }
     const now = Date.now()
     const normalized = quietDomains.map((entry: any) => {
         if (!entry || typeof entry.offset !== 'number') return entry
@@ -14,6 +18,7 @@ const applyQuietDomainsUpdate = async (quietDomains: any[]) => {
         return { ...rest, time: [now, now + offset] }
     })
     await storage.set('quietDomains', normalized)
+    logger.info(`[quiet-sync] Quiet-domains list replaced from server`, { count: normalized.length })
 }
 
 export default applyQuietDomainsUpdate;

--- a/extension-files/bringweb3-sdk/utils/background/followups.ts
+++ b/extension-files/bringweb3-sdk/utils/background/followups.ts
@@ -3,6 +3,7 @@ import validateDomain from "../api/validateDomain"
 import applyQuietDomainsUpdate from "./applyQuietDomainsUpdate"
 import parseUrl from "../parseUrl"
 import { searchRegexArray } from "./domainsListSearch"
+import { logger } from "../logger"
 
 // Server-defined navigation watchers persisted across SW restarts. See WORKFLOW.md.
 
@@ -96,6 +97,8 @@ export const armFollowups = async (incoming: any, originatingTabId?: number) => 
         const existing = await read()
         await write(existing.concat(newRecords))
     })
+
+    logger.debug(`[followup] Armed navigation watchers`, { tabId: originatingTabId, count: newRecords.length, ids: newRecords.map(r => r.id) })
 }
 
 export const processNavigation = async (tabId: number, url: string): Promise<any | null> => {
@@ -110,11 +113,16 @@ export const processNavigation = async (tabId: number, url: string): Promise<any
         const records = await read()
         if (!records.length) return
 
+        logger.debug(`[followup] Evaluating navigation against watchers`, { tabId, url, records: records.length })
+
         const dropped = new Set<FollowupRecord>()
 
         for (const rec of records) {
             if (rec.tabId !== null && rec.tabId !== tabId) continue
-            if (!rec.triggerRegex || !rec.ctlRegex) { dropped.add(rec); continue }
+            if (!rec.triggerRegex || !rec.ctlRegex) {
+                logger.debug(`[followup] Dropping watcher — missing compiled regex`, { tabId, id: rec.id })
+                dropped.add(rec); continue
+            }
 
             // Scope gates everything: an out-of-scope navigation can't fire or spend
             // budget, so skip the trigger check entirely. An in-scope navigation costs
@@ -122,14 +130,17 @@ export const processNavigation = async (tabId: number, url: string): Promise<any
             const scopeMatch = await matchTrigger(rec.ctlRegex, url, rec.ctl.type)
             if (!scopeMatch) continue
             rec.ctl.cnt -= 1
+            logger.debug(`[followup] Watcher in scope — spent 1 budget`, { tabId, id: rec.id, type: rec.ctl.type, cntLeft: rec.ctl.cnt })
 
             const triggerMatch = await matchTrigger(rec.triggerRegex, url, rec.ctl.type)
             if (triggerMatch) {
                 if (rec.ctl.type === 't') {
+                    logger.debug(`[followup] Trigger matched (TOF) — firing and dropping watcher`, { tabId, id: rec.id })
                     fired.push({ ...rec, matches: [triggerMatch] })
                     dropped.add(rec)
                     continue
                 } else {
+                    logger.debug(`[followup] Trigger matched (FOT) — accumulating match`, { tabId, id: rec.id, matches: rec.matches.length + 1 })
                     rec.matches.push(triggerMatch)
                 }
             }
@@ -138,9 +149,13 @@ export const processNavigation = async (tabId: number, url: string): Promise<any
         for (const rec of records) {
             if (dropped.has(rec)) continue
             if (rec.ctl.cnt <= 0) {
-                if (rec.ctl.type === 'f') fired.push({ ...rec, matches: rec.matches.slice() })
+                if (rec.ctl.type === 'f') {
+                    logger.debug(`[followup] Budget exhausted (FOT) — firing on terminate`, { tabId, id: rec.id, matches: rec.matches.length })
+                    fired.push({ ...rec, matches: rec.matches.slice() })
+                }
                 dropped.add(rec)
             } else if (rec.expiresAt <= now) {
+                logger.debug(`[followup] Watcher expired (TTL) — dropping`, { tabId, id: rec.id })
                 dropped.add(rec)
             }
         }
@@ -149,6 +164,8 @@ export const processNavigation = async (tabId: number, url: string): Promise<any
     })
 
     if (!fired.length) return null
+
+    logger.info(`[followup] Followup(s) fired — reposting to server`, { tabId, url, count: fired.length })
 
     // All fires repost to /check/popup — the backend dispatches by id
     // (emits analytics for TnxAnalytics, returns a popup payload for others, …).
@@ -167,10 +184,12 @@ export const processNavigation = async (tabId: number, url: string): Promise<any
         if (response?.quietDomainsChanged === true) {
             await applyQuietDomainsUpdate(response.quietDomains)
         }
+        logger.info(`[followup] Server response for fired followups`, { tabId, isValid: response?.isValid, iframeUrl: response?.iframeUrl, hasFollowups: Array.isArray(response?.followups) })
         // Return the full response — the caller (handleTabEvents.handlePopupResponse) decides
         // what to do based on isValid / verifiedMatch / followups (mirrors validateAndInject).
         return response ?? null
-    } catch {
+    } catch (error) {
+        logger.error(`[followup] Server repost failed`, error)
         return null
     }
 }

--- a/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
+++ b/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
@@ -57,6 +57,8 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
     const injectPopup = async (tabId: number, tab: chrome.tabs.Tab, popupData: any, phase: string, address: WalletAddress, sourceUrl?: string, isSpaNavigation: boolean = false) => {
         const userId = await getUserId()
 
+        logger.info(`[inject] Sending open-popup request to content script`, { tabId, phase, domain: parseUrl(tab.url!), iframeUrl: popupData.iframeUrl, flowId: popupData.flowId, isSpaNavigation });
+
         const res = await sendMessage(tabId, {
             action: 'INJECT',
             token: popupData.token,
@@ -71,6 +73,8 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             framed: popupData.framed,
             isSpaNavigation
         });
+
+        logger.info(`[inject] Content script replied to open-popup request`, { tabId, phase, status: res?.status, action: res?.action, message: res?.message });
 
         if (res?.action) {
             switch (res.action) {
@@ -98,20 +102,33 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
 
     const validateAndInject = async (urlToCheck: string, tabId: number, tab: chrome.tabs.Tab, isInlineSearch: boolean = false, inlineSearchResult?: { match: string | string[], type?: string }, isSpaNavigation: boolean = false) => {
 
-        if (isInlineSearch && tabStates.get(tabId)?.urlSearchStatus == 'succeeded') return;
+        // Inline search scans every link on the page (often 50-100), mostly non-matching. Logging each one
+        // buries the signal, so inline links only log once they actually match; the main URL logs every step.
+        if (!isInlineSearch) logger.debug(`[popup-check] Starting popup evaluation`, { tabId, urlToCheck, isSpaNavigation });
+
+        if (isInlineSearch && tabStates.get(tabId)?.urlSearchStatus == 'succeeded') {
+            logger.debug(`[popup-check] Skipped inline search — main URL search already succeeded`, { tabId });
+            return;
+        }
 
         const url = parseUrl(urlToCheck);
 
         const { matched, match, type } = await getRelevantDomain(urlToCheck, isInlineSearch ? 's' : 'kd');
 
         if (!matched) {
-            if (!isInlineSearch) await showNotification(tabId, cashbackPagePath, url, showNotifications, notificationCallback)
+            if (!isInlineSearch) {
+                logger.info(`[popup-check] No popup — domain not in relevant-domains list`, { tabId, url });
+                await showNotification(tabId, cashbackPagePath, url, showNotifications, notificationCallback)
+            }
             return;
         };
+
+        logger.debug(`[popup-check] Domain matched`, { tabId, url, match, type, isInlineSearch });
 
         if (isInlineSearch) {
             const state = tabStates.get(tabId);
             if (state?.inlineSearch?.status === "matched") {
+                logger.debug(`[popup-check] Skipped inline search — tab already matched`, { tabId });
                 return;
             }
             if (!state) {
@@ -122,6 +139,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
         }
 
         const { phase, payload } = await getQuietDomain(url, type);
+        logger.info(`[popup-check] Domain phase resolved`, { tabId, url, phase });
 
         const matches = [];
         if (isInlineSearch && inlineSearchResult) {
@@ -135,13 +153,17 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             const optOut = await storage.get('optOut');
 
             if (isMsRangeActive(optOut, now)) {
+                logger.info(`[popup-check] No popup — user opted out (global cooldown active)`, { tabId, url });
                 return;
             } else {
                 await storage.remove('optOut')
             }
         } else if (phase === 'activated') {
+            logger.info(`[inject] Showing activated popup (post-activation re-show)`, { tabId, url });
             const userId = await getUserId()
             const { iframeUrl, token, placement } = payload || {};
+
+            logger.info(`[inject] Sending open-popup request to content script`, { tabId, phase, domain: url, iframeUrl, isSpaNavigation });
 
             const res = await sendMessage(tabId, {
                 action: 'INJECT',
@@ -153,9 +175,11 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
                 placement,  // Pass placement configuration from payload
                 isSpaNavigation
             });
+            logger.info(`[inject] Content script replied to open-popup request`, { tabId, phase, status: res?.status, action: res?.action, message: res?.message });
             return;
         } else if (phase === 'quiet') {
             // TODO: if(phase === 'quiet') => Purchase-detector
+            logger.info(`[popup-check] No popup — domain is quiet phase`, { tabId, url });
             await showNotification(tabId, cashbackPagePath, url, showNotifications, notificationCallback)
             return
         }
@@ -185,6 +209,8 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             await applyQuietDomainsUpdate(popupData.quietDomains);
         }
 
+        logger.info(`[popup-check] Server validation result`, { tabId, url, isValid: popupData?.isValid, networkUrl: popupData?.networkUrl });
+
         if (!popupData.time) popupData.time = DAY_MS;
 
         if (Array.isArray(popupData.followups)) {
@@ -192,6 +218,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
         }
 
         if (popupData.isValid === false) {
+            logger.info(`[popup-check] No popup — server rejected, marking domain quiet`, { tabId, url, match: popupData.verifiedMatch?.match });
             addQuietDomain(popupData.verifiedMatch.match, popupData.time, popupData.quietDomainType, popupData.verifiedMatch.isRegex);
 
             if (isInlineSearch) return;
@@ -204,14 +231,21 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             popupData = state.inlineSearch.popupData;
         }
 
-        if (!await isWhitelisted(popupData.networkUrl)) return;
+        if (!await isWhitelisted(popupData.networkUrl)) {
+            logger.info(`[popup-check] No popup — network URL not whitelisted`, { tabId, url, networkUrl: popupData.networkUrl });
+            return;
+        }
 
         if (!isInlineSearch) {
             tabStates.get(tabId)!.urlSearchStatus = 'succeeded';
         } else {
             const state = tabStates.get(tabId);
-            if (state?.urlSearchStatus === 'succeeded') return;
+            if (state?.urlSearchStatus === 'succeeded') {
+                logger.debug(`[popup-check] Skipped inline inject — main URL search already succeeded`, { tabId });
+                return;
+            }
             if (state?.urlSearchStatus === 'pending') {
+                logger.debug(`[popup-check] Deferred inline popup — main URL search still pending`, { tabId });
                 state.inlineSearch = { status: "matched", popupData };
                 return;
             }
@@ -239,14 +273,20 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
 
         const uniqueLinks = [...new Set(response.links)] as string[];
 
+        logger.info(`[popup-check] Inline search — checking page links`, { tabId, url, links: uniqueLinks.length });
+
         await Promise.allSettled(
             uniqueLinks.map(link => validateAndInject(link, tabId, tab, true, { match: inlineSearchResult.match, type: inlineSearchResult.type }))
         );
     };
 
     const onMainNavigation = async (tabId: number, url: string, isSpaNavigation: boolean = false) => {
+        logger.info(`[flow] Handling navigation`, { tabId, url, isSpaNavigation });
         const isPopupEnabled = await storage.get('popupEnabled');
-        if (!isPopupEnabled) return;
+        if (!isPopupEnabled) {
+            logger.debug(`[flow] Skipped — popup disabled by user`, { tabId, url });
+            return;
+        }
 
         const tab = await chrome.tabs.get(tabId);
         tabStates.delete(tabId);
@@ -259,8 +299,11 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
                 await armFollowups(followupResult.followups, tabId).catch(() => { });
             }
             if (followupResult.iframeUrl && await isWhitelisted(followupResult.networkUrl)) {
+                logger.info(`[followup] Eligible — showing followup popup`, { tabId, url, iframeUrl: followupResult.iframeUrl });
                 const address = await getWalletAddress(tabId);
                 await injectPopup(tabId, tab, followupResult, 'new', address, url, isSpaNavigation);
+            } else {
+                logger.debug(`[followup] No popup from followup — no iframe or network not whitelisted`, { tabId, url, iframeUrl: followupResult.iframeUrl, networkUrl: followupResult.networkUrl });
             }
         }).catch(() => { });
 
@@ -271,6 +314,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
         // Full navigations — always processes.
         chrome.webNavigation.onCommitted.addListener(async ({ tabId, frameId, url }) => {
             if (frameId !== 0) return;
+            logger.debug(`[nav] URL changed (full page navigation)`, { tabId, url });
             const entry = navUrls.get(tabId);
             entry ? (entry.committed = url) : navUrls.set(tabId, { committed: url });
             onMainNavigation(tabId, url).catch(() => {});
@@ -279,7 +323,11 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
         // SPA navigations — only processes if onCommitted hasn't handled this URL.
         chrome.webNavigation.onHistoryStateUpdated.addListener(async ({ tabId, frameId, url }) => {
             if (frameId !== 0) return;
-            if (navUrls.get(tabId)?.committed === url) return;
+            if (navUrls.get(tabId)?.committed === url) {
+                logger.debug(`[nav] SPA URL change ignored — already handled by full navigation`, { tabId, url });
+                return;
+            }
+            logger.debug(`[nav] URL changed (SPA / history state update)`, { tabId, url });
             const entry = navUrls.get(tabId);
             entry ? (entry.history = url) : navUrls.set(tabId, { history: url });
             onMainNavigation(tabId, url, true).catch(() => {});
@@ -295,6 +343,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             if (!tab?.url?.startsWith('http')) return;
 
             if (changeInfo.url) {
+                logger.debug(`[nav] URL changed (tab-update fallback)`, { tabId, url: tab.url });
                 onMainNavigation(tabId, tab.url).catch(() => {});
             }
 

--- a/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
+++ b/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
@@ -231,10 +231,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             popupData = state.inlineSearch.popupData;
         }
 
-        if (!await isWhitelisted(popupData.networkUrl)) {
-            logger.info(`[popup-check] No popup — network URL not whitelisted`, { tabId, url, networkUrl: popupData.networkUrl });
-            return;
-        }
+        if (!await isWhitelisted(popupData.networkUrl)) return;
 
         if (!isInlineSearch) {
             tabStates.get(tabId)!.urlSearchStatus = 'succeeded';
@@ -305,7 +302,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             } else {
                 logger.debug(`[followup] No popup from followup — no iframe or network not whitelisted`, { tabId, url, iframeUrl: followupResult.iframeUrl, networkUrl: followupResult.networkUrl });
             }
-        }).catch(() => { });
+        }).catch(error => logger.error(`[followup] Followup handling failed`, error));
 
         await validateAndInject(url, tabId, tab, false, undefined, isSpaNavigation);
     };
@@ -317,7 +314,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             logger.debug(`[nav] URL changed (full page navigation)`, { tabId, url });
             const entry = navUrls.get(tabId);
             entry ? (entry.committed = url) : navUrls.set(tabId, { committed: url });
-            onMainNavigation(tabId, url).catch(() => {});
+            onMainNavigation(tabId, url).catch(error => logger.error(`[flow] Navigation handling failed`, error));
         }, { url: [{ schemes: ['http', 'https'] }] });
 
         // SPA navigations — only processes if onCommitted hasn't handled this URL.
@@ -330,12 +327,12 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             logger.debug(`[nav] URL changed (SPA / history state update)`, { tabId, url });
             const entry = navUrls.get(tabId);
             entry ? (entry.history = url) : navUrls.set(tabId, { history: url });
-            onMainNavigation(tabId, url, true).catch(() => {});
+            onMainNavigation(tabId, url, true).catch(error => logger.error(`[flow] Navigation handling failed`, error));
         }, { url: [{ schemes: ['http', 'https'] }] });
 
         chrome.webNavigation.onCompleted.addListener(async ({ tabId, frameId, url }) => {
             if (frameId !== 0) return;
-            onPageComplete(tabId, url).catch(() => {});
+            onPageComplete(tabId, url).catch(error => logger.error(`[popup-check] Inline search failed`, error));
         }, { url: [{ schemes: ['http', 'https'] }] });
     } else {
         // Fallback when webNavigation permission is unavailable.
@@ -344,11 +341,11 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
 
             if (changeInfo.url) {
                 logger.debug(`[nav] URL changed (tab-update fallback)`, { tabId, url: tab.url });
-                onMainNavigation(tabId, tab.url).catch(() => {});
+                onMainNavigation(tabId, tab.url).catch(error => logger.error(`[flow] Navigation handling failed`, error));
             }
 
             if (changeInfo.status === 'complete') {
-                onPageComplete(tabId, tab.url).catch(() => {});
+                onPageComplete(tabId, tab.url).catch(error => logger.error(`[popup-check] Inline search failed`, error));
             }
         });
     }

--- a/extension-files/bringweb3-sdk/utils/background/isWhitelisted.ts
+++ b/extension-files/bringweb3-sdk/utils/background/isWhitelisted.ts
@@ -20,11 +20,16 @@ const isWhitelisted = async (url: string): Promise<boolean> => {
             whitelist = await storage.get('redirectsWhitelist')
         }
 
-        if (!whitelist?.length) return false
+        if (!whitelist?.length) {
+            logger.warn('[whitelist] Not whitelisted — whitelist is empty after cache refresh', { url })
+            return false
+        }
 
         const domain = getDomain(url)
 
         const { matched } = searchArray(whitelist, domain)
+
+        if (!matched) logger.info('[whitelist] Not whitelisted — domain not in redirects whitelist', { url, domain })
 
         return matched;
 


### PR DESCRIPTION
Trace navigation -> popup decision end-to-end via the storage-gated logger, tagged by stage: [nav], [flow], [popup-check], [inject], [content], [followup], [quiet-sync], [activate]. info = an outcome happened, debug = mechanics. Gated by the debugMode flag, off by default.
Add debug logs through the popup flow
https://github.com/Bring-Web3-LTD/TODO/issues/467