### PR TITLE
feat(terms): inject per-retailer cashback rate into terms markdown

### DIFF
--- a/iframe-frontend/src/components/OfferTerms/OfferTerms.tsx
+++ b/iframe-frontend/src/components/OfferTerms/OfferTerms.tsx
@@ -5,6 +5,7 @@ import Markdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import { sendMessage, ACTIONS } from '../../utils/sendMessage'
 import { useWalletAddress } from '../../hooks/useWalletAddress'
+import injectCashback from '../../utils/injectCashback'
 import { ENV } from '../../config'
 
 interface Props {
@@ -17,7 +18,10 @@ const OfferTerms = ({ onBack }: Props) => {
         platformName,
         topGeneralTermsUrl,
         retailerTermsUrl,
-        generalTermsUrl
+        generalTermsUrl,
+        maxCashback,
+        cashbackSymbol,
+        cashbackCurrency
     } = useRouteLoaderData('root') as LoaderData
 
     const [markdownContent, setMarkdownContent] = useState('')
@@ -33,7 +37,7 @@ const OfferTerms = ({ onBack }: Props) => {
                     fetch(generalTermsUrl, { signal: controller.signal }).then(res => res.text())
                 ])
 
-                setMarkdownContent(topGeneral + retailer + general)
+                setMarkdownContent(injectCashback(topGeneral + retailer + general, { maxCashback, cashbackSymbol, cashbackCurrency }))
             } catch (error: unknown) {
                 if (error instanceof Error && error.name !== 'AbortError') {
                     console.error("Error fetching markdown:", error)

--- a/iframe-frontend/src/pages/Activated/Activated.tsx
+++ b/iframe-frontend/src/pages/Activated/Activated.tsx
@@ -9,10 +9,11 @@ import Markdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import { sendMessage, ACTIONS } from '../../utils/sendMessage'
 import { getIframeStyle } from '../../utils/iframeStyles'
+import injectCashback from '../../utils/injectCashback'
 import { ENV, ACTIVATE_QUIET_TIME, OB_ACTIVATE_QUIET_TIME } from '../../config'
 
 const Activated = () => {
-    const { version, topGeneralTermsUrl, retailerTermsUrl, generalTermsUrl, platformName, displayPlatformName, tokenSymbol, isOfferBar, iframeStyle: themeIframeStyle, zIndex } = useRouteLoaderData('root') as ActivatedData & { iframeStyle?: Record<string, string> }
+    const { version, topGeneralTermsUrl, retailerTermsUrl, generalTermsUrl, platformName, displayPlatformName, tokenSymbol, isOfferBar, iframeStyle: themeIframeStyle, zIndex, maxCashback, cashbackSymbol, cashbackCurrency } = useRouteLoaderData('root') as ActivatedData & { iframeStyle?: Record<string, string> }
     const { walletAddress } = useWalletAddress()
     const [markdownContent, setMarkdownContent] = useState('')
     // const [loading, setLoading] = useState(true)
@@ -31,7 +32,7 @@ const Activated = () => {
                     fetch(generalTermsUrl, { signal: controller.signal }).then(res => res.text())
                 ])
 
-                setMarkdownContent(topGeneral + retailer + general)
+                setMarkdownContent(injectCashback(topGeneral + retailer + general, { maxCashback, cashbackSymbol, cashbackCurrency }))
             } catch (error: unknown) {
                 if (error instanceof Error && error.name !== 'AbortError') {
                     console.error("Error fetching markdown:", error)

--- a/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
+++ b/iframe-frontend/src/templates/b/OneStep/OneStep.tsx
@@ -15,6 +15,7 @@ import { Oval } from 'react-loader-spinner'
 // Functions
 import activate from "../../../api/activate"
 import formatCashback from "../../../utils/formatCashback"
+import injectCashback from "../../../utils/injectCashback"
 import splitStringWithDots from "../../../utils/splitStringWithDots"
 import { sendMessage, ACTIONS } from "../../../utils/sendMessage"
 import { ACTIVATE_QUIET_TIME, ENV } from "../../../config"
@@ -65,7 +66,7 @@ const OneStep = () => {
                     fetch(generalTermsUrl, { signal: controller.signal }).then(res => res.text())
                 ])
 
-                setMarkdownContent(topGeneral + retailer + general)
+                setMarkdownContent(injectCashback(topGeneral + retailer + general, { maxCashback, cashbackSymbol, cashbackCurrency }))
             } catch (error: unknown) {
                 if (error instanceof Error && error.name !== 'AbortError') {
                     console.error("Error fetching markdown:", error)

--- a/iframe-frontend/src/utils/injectCashback.ts
+++ b/iframe-frontend/src/utils/injectCashback.ts
@@ -1,0 +1,16 @@
+import formatCashback from './formatCashback'
+
+/**
+ * Replaces {{cashback}} marks in terms markdown with the retailer's formatted
+ * cashback rate, so the mass-uploaded general MD can show per-retailer values
+ * without manual edits. Markdown without the mark passes through unchanged.
+ */
+const CASHBACK_MARK = /\{\{\s*cashback\s*\}\}/gi
+
+const injectCashback = (
+    markdown: string,
+    { maxCashback, cashbackSymbol, cashbackCurrency }: Pick<Info, 'maxCashback' | 'cashbackSymbol' | 'cashbackCurrency'>
+): string =>
+    markdown.replace(CASHBACK_MARK, formatCashback(+maxCashback, cashbackSymbol, cashbackCurrency))
+
+export default injectCashback


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/131
______
Add injectCashback util that replaces {{cashback}} marks in the fetched terms MD with the retailer's formatted maxCashback, and apply it in OfferTerms, Activated, and template-b OneStep. Lets the mass-uploaded general terms show dynamic per-retailer values without manual edits.