### PR TITLE
fix(widget): restore AB slide-in when popup mounts already expanded

### DIFF
--- a/iframe-frontend/src/components/Widget/Widget.tsx
+++ b/iframe-frontend/src/components/Widget/Widget.tsx
@@ -1,10 +1,10 @@
 import styles from './styles.module.css'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouteLoaderData } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import Offer from '../Offer/Offer'
 import { sendMessage, ACTIONS } from '../../utils/sendMessage'
-import { getIframeStyle } from '../../utils/iframeStyles'
+import { getIframeStyle, slideInAnimation } from '../../utils/iframeStyles'
 import { widgetStorageKey, wasWidgetExpanded } from '../../utils/widgetSession'
 import { useAnalytics } from '../../hooks/useAnalytics'
 
@@ -35,6 +35,13 @@ const Widget = ({ closeFn }: Props) => {
     const storageKey = useMemo(() => widgetStorageKey(platformName), [platformName])
 
     const [mode, setMode] = useState<Mode>(() => wasWidgetExpanded(platformName) ? 'expanded' : 'collapsed')
+
+    // True while this page load sits in the expanded state it MOUNTED in (persisted via
+    // sessionStorage from a previous navigation). In that flow there's no badge-to-AB
+    // framer transition, so the iframe keeps the standard AB slide-in instead of the
+    // widgetExpanded `animation: none`. Cleared once the mode changes, so a future
+    // collapse → re-expand animates with framer only, like a first-time expand.
+    const mountedExpanded = useRef(mode === 'expanded')
 
     // Falls back to the generic PlatformLogo (md) if a platform has no dedicated badge mark.
     const [markFailed, setMarkFailed] = useState(false)
@@ -67,6 +74,11 @@ const Widget = ({ closeFn }: Props) => {
         // receive clicks instead of the invisible iframe blocking them. Must be reset
         // explicitly in every other mode because applyStyles never clears keys.
         target.pointerEvents = mode === 'returning' ? 'none' : 'auto'
+        // Navigations that mount straight into the expanded AB get the regular popup
+        // slide-in (widgetExpanded disables it only because framer animates the
+        // interactive badge-to-AB expand, which doesn't run here).
+        if (mode === 'expanded' && mountedExpanded.current) target.animation = slideInAnimation
+        else if (mode !== 'expanded') mountedExpanded.current = false
         sendMessage({ action: ACTIONS.OPEN, style })
     }, [mode, popupSized, platformName, version, themeIframeStyle, zIndex])
 

--- a/iframe-frontend/src/utils/iframeStyles.ts
+++ b/iframe-frontend/src/utils/iframeStyles.ts
@@ -10,10 +10,13 @@ interface KeyFrames {
 
 export type IframePage = 'popup' | 'offerbar' | 'offerbarFramed' | 'notification' | 'widget' | 'widgetExpanded'
 
+// The standard entrance animation shared by every surface (keyframes in `keyFrames` below).
+export const slideInAnimation = 'slideIn .3s ease-in-out'
+
 const iframeStyle: Styles = {
     default: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '480px',
             height: `435px`,
             borderRadius: '8px',
@@ -23,7 +26,7 @@ const iframeStyle: Styles = {
     },
     yoroi: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '480px',
             height: `436px`,
             borderRadius: '16px',
@@ -33,7 +36,7 @@ const iframeStyle: Styles = {
     },
     argent: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '360px',
             height: `600px`,
             borderRadius: '0px',
@@ -46,7 +49,7 @@ const iframeStyle: Styles = {
 const offerbarStyle: Styles = {
     default: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '93px',
             height: `482px`,
             borderRadius: '100px 0 0 100px',
@@ -62,7 +65,7 @@ const offerbarFramedStyle: Styles = {
         iframe: {
             position: 'fixed',
             inset: '0',
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             height: '71px',
             width: `100vw`,
             borderRadius: '0px',
@@ -106,7 +109,8 @@ const widgetStyle: Styles = {
 // duplicating sizes - only the deltas differ:
 //  - top/right: anchored at the badge position so the AB grows out of the badge.
 //  - animation: the scale/fade is done inside the iframe (framer-motion), so the
-//    CSS slideIn is disabled.
+//    CSS slideIn is disabled. (Widget restores it when a navigation mounts straight
+//    into the expanded AB, where no framer transition runs.)
 //  - clipPath: cleared, since applyStyles only sets keys (never clears them) and the
 //    collapsed badge's clip would otherwise linger and crop the AB.
 const applyIframeOverrides = (styles: Styles, overrides: Record<string, string>): Styles => {
@@ -131,7 +135,7 @@ const widgetExpandedStyle: Styles = applyIframeOverrides(iframeStyle, {
 const notificationIframeStyle: Styles = {
     default: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '480px',
             height: `56px`,
             borderRadius: '10px',
@@ -142,7 +146,7 @@ const notificationIframeStyle: Styles = {
     },
     yoroi: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '480px',
             height: `56px`,
             borderRadius: '12px',
@@ -153,7 +157,7 @@ const notificationIframeStyle: Styles = {
     },
     argent: {
         iframe: {
-            animation: 'slideIn .3s ease-in-out',
+            animation: slideInAnimation,
             width: '400px',
             height: `50px`,
             borderRadius: '10px',

--- a/iframe-frontend/src/utils/iframeStyles.ts
+++ b/iframe-frontend/src/utils/iframeStyles.ts
@@ -10,7 +10,7 @@ interface KeyFrames {
 
 export type IframePage = 'popup' | 'offerbar' | 'offerbarFramed' | 'notification' | 'widget' | 'widgetExpanded'
 
-// The standard entrance animation shared by every surface (keyframes in `keyFrames` below).
+// The standard entrance animation used by popup-like surfaces (keyframes in `keyFrames` below).
 export const slideInAnimation = 'slideIn .3s ease-in-out'
 
 const iframeStyle: Styles = {
@@ -210,13 +210,12 @@ export const getIframeStyle = (
         ? { ...themeIframeStyle, zIndex: String(zIndex) }
         : themeIframeStyle
 
+    // Always spread into a fresh object: callers mutate the result (e.g. Widget strips
+    // boxShadow / restores the slide-in per mode), which must never leak back into the
+    // shared style-map singletons above.
     if (isLegacy) {
-        return iframeStyleOverrides
-            ? { ...baseIframeStyle.iframe, ...iframeStyleOverrides }
-            : baseIframeStyle.iframe
+        return { ...baseIframeStyle.iframe, ...iframeStyleOverrides }
     }
 
-    return iframeStyleOverrides
-        ? { iframe: { ...baseIframeStyle.iframe, ...iframeStyleOverrides } }
-        : baseIframeStyle
+    return { iframe: { ...baseIframeStyle.iframe, ...iframeStyleOverrides } }
 }


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/481
________
After a widget click, same-tab navigations mount the popup directly in the expanded state: the framer badge-to-AB transition is skipped and the widgetExpanded iframe style sets animation none, so the AB appeared with no animation at all. Track whether the page loaded straight into the expanded state and re-apply the standard slideIn animation on the iframe in that case, keeping the interactive expand (framer-only) unchanged. Extract the shared slideIn value into a slideInAnimation constant.