### PR TITLE
feat(widget): add isWidget flag to widget-originated analytics events

### DIFF
--- a/iframe-frontend/src/Layout/Layout.tsx
+++ b/iframe-frontend/src/Layout/Layout.tsx
@@ -1,5 +1,6 @@
-import { Outlet, useLoaderData } from "react-router-dom"
-import { useEffect } from "react"
+import { Outlet, useLoaderData, useLocation } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { wasWidgetExpanded } from "../utils/widgetSession"
 import { AnalyticsProvider } from "../context/analyticsContext"
 import { useAnalytics } from "../hooks/useAnalytics"
 import WalletAddressProvider from "../context/walletAddressContext"
@@ -28,6 +29,14 @@ const AutoCloseTimer = ({ timeout }: { timeout?: number }) => {
 
 const Layout = () => {
     const data = useLoaderData() as LoaderData
+    const { pathname } = useLocation()
+    // True when this page load starts as the collapsed widget badge (popup route,
+    // widget enabled, not restored expanded from a previous page in this tab). Read
+    // once on mount: expanding later writes 'true' to sessionStorage, and a re-render
+    // must not flip this after the page_view already went out.
+    const [pageViewIsWidget] = useState(() =>
+        pathname === '/' && !!data.isWidgetEnabled && !wasWidgetExpanded(data.platformName)
+    )
 
     return (
         <>
@@ -46,6 +55,7 @@ const Layout = () => {
                     inlineSearchLink={data.inlineSearchLink}
                     matchedKeyword={data.matchedKeyword}
                     isOfferBar={data.isOfferBar}
+                    pageViewIsWidget={pageViewIsWidget}
                 >
                     <Beamer enabled={data.beamer} />
                     <AutoCloseTimer timeout={data.timeout} />

--- a/iframe-frontend/src/api/analytics.ts
+++ b/iframe-frontend/src/api/analytics.ts
@@ -21,6 +21,7 @@ interface Body {
     resultUrl?: string
     matchedKeyword?: string
     isOfferBar?: boolean
+    isWidget?: boolean
 }
 
 const analytics = async (body: Body,timestamp?: number) => {

--- a/iframe-frontend/src/components/Widget/Widget.tsx
+++ b/iframe-frontend/src/components/Widget/Widget.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import Offer from '../Offer/Offer'
 import { sendMessage, ACTIONS } from '../../utils/sendMessage'
 import { getIframeStyle } from '../../utils/iframeStyles'
+import { widgetStorageKey, wasWidgetExpanded } from '../../utils/widgetSession'
 import { useAnalytics } from '../../hooks/useAnalytics'
 
 interface Props {
@@ -29,21 +30,11 @@ const Widget = ({ closeFn }: Props) => {
         zIndex,
     } = useRouteLoaderData('root') as LoaderData
 
-    // One widget state per wallet. Several wallet extensions may embed this app on the same
-    // page, all from the same origin - so they share sessionStorage, and the platform name
-    // is what keeps each wallet's expand/collapse state separate. No need to also key by
-    // retailer: the browser already stores this iframe's data per top-level site (and per tab).
-    const storageKey = useMemo(() => `bring:widget:${platformName}`, [platformName])
+    // No need to also key by retailer: the browser already stores this iframe's data
+    // per top-level site (and per tab).
+    const storageKey = useMemo(() => widgetStorageKey(platformName), [platformName])
 
-    const [mode, setMode] = useState<Mode>(() => {
-        try {
-            const stored = sessionStorage.getItem(storageKey)
-            if (stored !== null) return stored === 'true' ? 'expanded' : 'collapsed'
-        } catch {
-            /* sessionStorage may be unavailable (e.g. partitioned) - start collapsed */
-        }
-        return 'collapsed'
-    })
+    const [mode, setMode] = useState<Mode>(() => wasWidgetExpanded(platformName) ? 'expanded' : 'collapsed')
 
     // Falls back to the generic PlatformLogo (md) if a platform has no dedicated badge mark.
     const [markFailed, setMarkFailed] = useState(false)
@@ -95,6 +86,7 @@ const Widget = ({ closeFn }: Props) => {
             category: 'user_action',
             action: 'click',
             details: { retailer: name, domain },
+            isWidget: true,
         })
         try {
             sessionStorage.setItem(storageKey, 'true')
@@ -203,7 +195,18 @@ const Widget = ({ closeFn }: Props) => {
                         aria-label="Dismiss"
                         // Stays mounted through the transitions so it scales with the badge,
                         // but is only actionable once fully collapsed.
-                        onClick={() => { if (mode === 'collapsed') closeFn() }}
+                        onClick={async () => {
+                            if (mode !== 'collapsed') return
+                            // Dismissing the badge is the widget's own close - unlike the
+                            // expanded AB's X, which sends the standard (unflagged) popup_close.
+                            await sendAnalyticsEvent('popup_close', {
+                                category: 'user_action',
+                                action: 'click',
+                                details: 'extension',
+                                isWidget: true,
+                            })
+                            closeFn()
+                        }}
                     >
                         <span
                             className={styles.closeIcon}

--- a/iframe-frontend/src/context/analyticsContext.tsx
+++ b/iframe-frontend/src/context/analyticsContext.tsx
@@ -9,8 +9,9 @@ type EventName = 'retailer_shop' | 'popup_close' | 'opt_out' | 'opt_out_specific
 interface AnalyticsEvent {
     category: "user_action" | "system";
     action?: "click" | "input" | "select" | "request"| "timeout";
-    details?: string | object;    
+    details?: string | object;
     process?: "activate" | "initiate" | "submit";
+    isWidget?: boolean;
 }
 
 interface BackendEvent {
@@ -18,6 +19,7 @@ interface BackendEvent {
     action?: "click" | "input" | "select" | "request" | "timeout";
     details?: unknown;
     process?: "activate" | "initiate" | "submit";
+    isWidget?: boolean;
 }
 
 
@@ -43,9 +45,12 @@ interface Props {
     inlineSearchLink: string | undefined
     matchedKeyword: string | undefined
     isOfferBar: boolean | undefined
+    // Flags ONLY the page_view event as widget-originated (page load started as the
+    // collapsed badge). Other events opt in per call site via event.isWidget.
+    pageViewIsWidget: boolean
 }
 
-export const AnalyticsProvider: FC<Props> = ({ children, platform, testVariant, userId, retailerName, location, flowId, searchEngineDomain, verifiedMatch, offerBarSearch, domain, inlineSearchLink, matchedKeyword, isOfferBar }) => {
+export const AnalyticsProvider: FC<Props> = ({ children, platform, testVariant, userId, retailerName, location, flowId, searchEngineDomain, verifiedMatch, offerBarSearch, domain, inlineSearchLink, matchedKeyword, isOfferBar, pageViewIsWidget }) => {
     const isInitialMount = useRef(true)
     const { walletAddress } = useWalletAddress()
     const previousWalletAddressRef = useRef<string | undefined>(walletAddress)
@@ -184,10 +189,13 @@ export const AnalyticsProvider: FC<Props> = ({ children, platform, testVariant, 
         }
         if (retailerName) details.retailer = retailerName
 
-        sendBackendEvent('page_view', {
+        const pageViewEvent: BackendEvent = {
             category: 'system',
             details
-        })
+        }
+        if (pageViewIsWidget) pageViewEvent.isWidget = true
+
+        sendBackendEvent('page_view', pageViewEvent)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/iframe-frontend/src/utils/widgetSession.ts
+++ b/iframe-frontend/src/utils/widgetSession.ts
@@ -1,0 +1,15 @@
+// One widget state per wallet. Several wallet extensions may embed this app on the same
+// page, all from the same origin - so they share sessionStorage, and the platform name
+// is what keeps each wallet's expand/collapse state separate.
+export const widgetStorageKey = (platformName: string) => `bring:widget:${platformName}`
+
+// Whether the widget starts this page load already expanded (persisted from a previous
+// expansion in this tab session).
+export const wasWidgetExpanded = (platformName: string) => {
+    try {
+        return sessionStorage.getItem(widgetStorageKey(platformName)) === 'true'
+    } catch {
+        /* sessionStorage may be unavailable (e.g. partitioned) - treat as collapsed */
+        return false
+    }
+}


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/482
_________
- widget_click and the badge X's popup_close (previously sent no event) are flagged isWidget: true
- page_view is flagged only when the page load starts as the collapsed badge (not when restored expanded from sessionStorage)
- events from the expanded AB stay unflagged
- extract the widget sessionStorage key/read into utils/widgetSession so Layout and Widget can't drift