### PR TITLE
fix: survive host-page hydration wiping the popup (GH#504)

### DIFF
--- a/extension-files/bringweb3-sdk/.changeset/brave-frames-return.md
+++ b/extension-files/bringweb3-sdk/.changeset/brave-frames-return.md
@@ -1,0 +1,5 @@
+---
+"@bringweb3/chrome-extension-kit": patch
+---
+
+Survive host-page React hydration recovery (GH#504): re-inject the popup when the host wipes it (bounded, stops after load), derive iframe-open state from the DOM, restore `flowId` on the activated popup, tolerate `document_start` stylesheet injection, and stop reporting `no_popup` when a popup is already open.

--- a/extension-files/bringweb3-sdk/.changeset/brave-frames-return.md
+++ b/extension-files/bringweb3-sdk/.changeset/brave-frames-return.md
@@ -2,4 +2,4 @@
 "@bringweb3/chrome-extension-kit": patch
 ---
 
-Survive host-page React hydration recovery (GH#504): re-inject the popup when the host wipes it (bounded, stops after load), derive iframe-open state from the DOM, restore `flowId` on the activated popup, tolerate `document_start` stylesheet injection, and stop reporting `no_popup` when a popup is already open.
+Re-inject the popup when host-page hydration wipes it

--- a/extension-files/bringweb3-sdk/bringInitContentScript.ts
+++ b/extension-files/bringweb3-sdk/bringInitContentScript.ts
@@ -15,10 +15,8 @@ let flowId: string | null = null
 // presence in the DOM is the only reliable signal.
 const isIframeOpen = () => !!document.getElementById(`${IFRAME_ID_PREFIX}-${chrome.runtime.id}`)
 
-// Self-heal: a host whose React root is `document` (e.g. Remix's hydrateRoot(document, …))
-// regenerates <html> on hydration recovery, wiping our iframe with it. Hydration happens
-// once, early, so a bounded re-inject is enough - not a loop. removeElements() disconnects
-// the observer first, so our own teardown paths never trigger a re-inject.
+// Self-heal: hosts that hydrate on `document` (e.g. Remix) can wipe our iframe,
+// so re-inject a bounded number of times. Our own teardown disconnects the observer first.
 const MAX_REINJECTS = 3
 let lastInject: Parameters<typeof injectIFrame>[0] | null = null
 let reinjects = 0

--- a/extension-files/bringweb3-sdk/bringInitContentScript.ts
+++ b/extension-files/bringweb3-sdk/bringInitContentScript.ts
@@ -4,12 +4,58 @@ import startListenersForWalletAddress from "./utils/contentScript/startLIsteners
 import getDomain from "./utils/getDomain.js";
 import removeTrailingSlash from "./utils/background/removeTrailingSlash.js";
 import { contentScriptCleanup } from "./utils/contentScript/cleanupManager.js";
+import { IFRAME_ID_PREFIX } from "./utils/constants.js";
 import { logger } from "./utils/logger.js";
 
 let iframeEl: IFrame = null
 let iframePath: `/${string}` | undefined = undefined
-let isIframeOpen = false
 let flowId: string | null = null
+
+// The host page can delete our nodes behind our back, so a flag desyncs;
+// presence in the DOM is the only reliable signal.
+const isIframeOpen = () => !!document.getElementById(`${IFRAME_ID_PREFIX}-${chrome.runtime.id}`)
+
+// Self-heal: a host whose React root is `document` (e.g. Remix's hydrateRoot(document, …))
+// regenerates <html> on hydration recovery, wiping our iframe with it. Hydration happens
+// once, early, so a bounded re-inject is enough - not a loop. removeElements() disconnects
+// the observer first, so our own teardown paths never trigger a re-inject.
+const MAX_REINJECTS = 3
+let lastInject: Parameters<typeof injectIFrame>[0] | null = null
+let reinjects = 0
+let settled = false
+
+// Created on first use: this module is bundled together with the background entry,
+// and MutationObserver doesn't exist in a service worker.
+let observer: MutationObserver | null = null
+
+// Past load(+2s) the DOM is hydrated; a host still removing our iframe is doing it
+// deliberately, so stop. Armed on the first successful INJECT - load has usually
+// already fired by the time an activated popup is injected.
+const settle = () => setTimeout(() => { settled = true; observer?.disconnect() }, 2000)
+
+const startSelfHeal = (payload: Parameters<typeof injectIFrame>[0]) => {
+    lastInject = payload
+    reinjects = 0
+    if (settled) return
+    // First injection only: create the observer and schedule the shutdown.
+    if (!observer) {
+        observer = new MutationObserver(() => {
+            if (isIframeOpen()) return
+            if (settled || reinjects >= MAX_REINJECTS || !lastInject) {
+                observer?.disconnect()
+                return
+            }
+            reinjects++
+            logger.info(`[content] Popup removed by the host page - re-injecting`, { attempt: reinjects })
+            contentScriptCleanup.cleanup()
+            iframeEl = injectIFrame(lastInject)
+        })
+        document.readyState === 'complete' ? settle() : window.addEventListener('load', settle, { once: true })
+    }
+    // subtree catches React replacing the <html> node itself - an observer on
+    // documentElement alone would be left watching a detached node.
+    observer.observe(document, { childList: true, subtree: true })
+}
 
 interface Configuration {
     getWalletAddress: () => Promise<WalletAddress>
@@ -23,7 +69,7 @@ interface Configuration {
 }
 
 const removeElements = () => {
-    isIframeOpen = false
+    observer?.disconnect()
     iframePath = undefined
     iframeEl = null
     contentScriptCleanup?.cleanup()
@@ -71,7 +117,7 @@ const bringInitContentScript = async ({
     switchWallet = false
 }: Configuration) => {
     if (window.self !== window.top && removeTrailingSlash(window.document.location.origin).endsWith('bringweb3.io')) {
-        logger.debug(`[popup-msg] Portal iframe detected — listening for PORTAL_ACTIVATE`, { origin: window.document.location.origin });
+        logger.debug(`[popup-msg] Portal iframe detected - listening for PORTAL_ACTIVATE`, { origin: window.document.location.origin });
 
         window.addEventListener('message', (e) => {
             if (!e.data || e.data.from !== 'bringweb3' || e.data.action !== 'PORTAL_ACTIVATE') return;
@@ -108,7 +154,8 @@ const bringInitContentScript = async ({
     window.addEventListener('message', (e) => handleIframeMessages({
         event: e,
         iframeEl,
-        promptLogin
+        promptLogin,
+        onClose: removeElements
     }))
 
     // Listen for message
@@ -161,7 +208,7 @@ const bringInitContentScript = async ({
                         logger.debug(`[content] Domain mismatch`, { current: getDomain(location.href), expected: getDomain(request.domain) });
                         sendResponse({ status: 'failed', message: 'Domain already changed' });
                         return true
-                    } else if (isIframeOpen) {
+                    } else if (isIframeOpen()) {
                         // On SPA navigations, pagehide doesn't fire, so close the old popup before injecting.
                         if (request.isSpaNavigation) {
                             logger.debug(`[content] SPA navigation — closing previous popup before re-injecting`);
@@ -176,7 +223,7 @@ const bringInitContentScript = async ({
                     const isReferrer = !!referrer && referrers.includes(getDomain(referrer))
 
                     if (isReferrer && request.page === '') {
-                        logger.info(`[content] No popup — cashback already activated by the referring page`);
+                        logger.info(`[content] No popup - cashback already activated by the referring page`);
                         logger.debug(`[content] Referrer match`, { referrer: getDomain(referrer) });
                         sendResponse({ status: 'failed', message: `already activated by ${getDomain(referrer)}`, action: 'activate' });
                         return true
@@ -187,7 +234,7 @@ const bringInitContentScript = async ({
                     const query: { [key: string]: string } = { token }
                     if (userId) query['userId'] = userId
 
-                    iframeEl = injectIFrame({
+                    const injectPayload: Parameters<typeof injectIFrame>[0] = {
                         query,
                         iframeUrl,
                         styleUrl,
@@ -198,10 +245,12 @@ const bringInitContentScript = async ({
                         placement,  // Pass placement configuration from server
                         stylesheet,
                         framed
-                    });
-                    isIframeOpen = true
+                    }
+                    iframeEl = injectIFrame(injectPayload);
                     iframePath = `/${request.page || ''}`
                     flowId = request.flowId
+                    // Only watch a popup that actually landed (placement.selector can miss).
+                    if (isIframeOpen()) startSelfHeal(injectPayload)
                     logger.info(`[content] Popup shown (iframe injected)`);
                     logger.debug(`[content] Popup details`, { domain: request.domain, page: request.page, flowId });
                     sendResponse({ status: 'success' });
@@ -222,6 +271,8 @@ const bringInitContentScript = async ({
     });
 
     window.addEventListener('pagehide', () => {
+        // Intentionally also on bfcache-persisted pages: onCommitted fires on
+        // restore and re-injects a fresh popup rather than resuming a frozen one.
         removeElements()
     })
 }

--- a/extension-files/bringweb3-sdk/utils/background/getQuietDomain.ts
+++ b/extension-files/bringweb3-sdk/utils/background/getQuietDomain.ts
@@ -7,6 +7,7 @@ type Phases = 'new' | 'activated' | 'quiet'
 interface Payload {
     iframeUrl?: string
     token?: string
+    flowId?: string
     placement?: PlacementConfig  // Optional placement configuration from server
 }
 

--- a/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
+++ b/extension-files/bringweb3-sdk/utils/background/handleTabEvents.ts
@@ -45,8 +45,9 @@ interface TabState {
 
 const tabStates = new Map<number, TabState>();
 
-// Tracks URLs per tab for each event source to coordinate between onCommitted and onHistoryStateUpdated.
-const navUrls = new Map<number, { committed?: string; history?: string }>();
+// Last handled URL per tab, to coordinate between onCommitted and onHistoryStateUpdated:
+// a history event for the exact URL onCommitted just handled is the same visit.
+const navUrls = new Map<number, string>();
 
 type StandDown = { hop: string, match: string | string[] } | null;
 
@@ -147,14 +148,19 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
         }
 
         if (res?.status !== 'success') {
-            logger.info(`[inject] No popup — content script did not show it`, { tabId, phase, status: res?.status, message: res?.message });
-            analytics({
-                type: 'no_popup',
-                userId,
-                walletAddress: address,
-                details: { url: sourceUrl ?? tab.url, match: popupData.verifiedMatch?.match, iframeUrl: popupData.iframeUrl, reason: res?.message, status: res?.status },
-                flowId: popupData.flowId
-            })
+            // 'iframe already open' means a popup is showing - not a no-popup outcome.
+            if (res?.message === 'iframe already open') {
+                logger.debug(`[inject] Popup already open - no_popup not reported`, { tabId, phase });
+            } else {
+                logger.info(`[inject] No popup — content script did not show it`, { tabId, phase, status: res?.status, message: res?.message });
+                analytics({
+                    type: 'no_popup',
+                    userId,
+                    walletAddress: address,
+                    details: { url: sourceUrl ?? tab.url, match: popupData.verifiedMatch?.match, iframeUrl: popupData.iframeUrl, reason: res?.message, status: res?.status },
+                    flowId: popupData.flowId
+                })
+            }
         }
 
         return res;
@@ -165,10 +171,10 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
     const injectActivatedPopup = async (tabId: number, url: string, payload: any, isSpaNavigation: boolean) => {
         logger.info(`[popup-check] Showing activated popup (post-activation re-show)`, { tabId, url });
         const userId = await getUserId();
-        const { iframeUrl, token, placement } = payload || {};
+        const { iframeUrl, token, flowId, placement } = payload || {};
 
         logger.info(`[bg-msg] INJECT event sent`);
-        logger.debug(`[bg-msg] INJECT payload`, { tabId, phase: 'activated', domain: url, iframeUrl, isSpaNavigation });
+        logger.debug(`[bg-msg] INJECT payload`, { tabId, phase: 'activated', domain: url, iframeUrl, flowId, isSpaNavigation });
 
         const res = await sendMessage(tabId, {
             action: 'INJECT',
@@ -177,6 +183,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
             domain: url,
             userId,
             page: 'activated',
+            flowId,
             placement,  // Pass placement configuration from payload
             isSpaNavigation
         });
@@ -417,8 +424,7 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
     chrome.webNavigation.onCommitted.addListener(async ({ tabId, frameId, url }) => {
         if (frameId !== 0) return;
         logger.debug(`[nav] URL changed (full page navigation)`, { tabId, url });
-        const entry = navUrls.get(tabId);
-        entry ? (entry.committed = url) : navUrls.set(tabId, { committed: url });
+        navUrls.set(tabId, url);
         onMainNavigation(tabId, url).catch(error => logger.error(`[flow] Navigation handling failed`, error));
     }, { url: [{ schemes: ['http', 'https'] }] });
 
@@ -426,13 +432,12 @@ const handleTabEvents = (cashbackPagePath: string | undefined, showNotifications
     // changes fire no request, so the chain still holds this visit's arrival hops.
     chrome.webNavigation.onHistoryStateUpdated.addListener(async ({ tabId, frameId, url }) => {
         if (frameId !== 0) return;
-        if (navUrls.get(tabId)?.committed === url) {
-            logger.debug(`[nav] SPA URL change ignored — already handled by full navigation`, { tabId, url });
+        if (navUrls.get(tabId) === url) {
+            logger.debug(`[nav] SPA URL change ignored — same URL already handled`, { tabId, url });
             return;
         }
         logger.debug(`[nav] URL changed (SPA / history state update)`, { tabId, url });
-        const entry = navUrls.get(tabId);
-        entry ? (entry.history = url) : navUrls.set(tabId, { history: url });
+        navUrls.set(tabId, url);
         onMainNavigation(tabId, url, true).catch(error => logger.error(`[flow] Navigation handling failed`, error));
     }, { url: [{ schemes: ['http', 'https'] }] });
 

--- a/extension-files/bringweb3-sdk/utils/contentScript/handleIframeMessages.ts
+++ b/extension-files/bringweb3-sdk/utils/contentScript/handleIframeMessages.ts
@@ -8,6 +8,7 @@ interface Props {
     event: BringEvent
     iframeEl: IFrame
     promptLogin: () => Promise<void>
+    onClose?: () => void
 }
 
 const ACTIONS = {
@@ -28,7 +29,7 @@ const UNION_ACTIONS = [ACTIONS.ACTIVATE]
 // Handled entirely in the content script — these never reach the background,
 const LOCAL_ACTIONS = [ACTIONS.OPEN, ACTIONS.ADD_KEYFRAMES, ACTIONS.PROMPT_LOGIN]
 
-const handleIframeMessages = ({ event, iframeEl, promptLogin }: Props) => {
+const handleIframeMessages = ({ event, iframeEl, promptLogin, onClose }: Props) => {
     if (!event?.data) return
 
     const { from, action, style, keyFrames, time, key, extensionId, url, domain, redirectUrl, iframeUrl, token, flowId, platformName, searchTermPattern, type, quietDomainType, isRegex, followups } = event.data
@@ -57,7 +58,11 @@ const handleIframeMessages = ({ event, iframeEl, promptLogin }: Props) => {
             }
             break;
         case ACTIONS.CLOSE:
-            contentScriptCleanup.cleanup()
+            // The iframe asked to close itself — the self-heal observer must be
+            // disconnected before the nodes go, or it reads this as a host wipe.
+            // onClose (removeElements) already runs the cleanup itself.
+            if (onClose) onClose()
+            else contentScriptCleanup.cleanup()
             if (time) chrome.runtime.sendMessage({ action, time, domain, type, isRegex, from: "bringweb3" })
             logger.debug(`[popup-msg] CLOSE — cleanup ran`, { forwardedToBackground: !!time, domain, time });
             break;

--- a/extension-files/bringweb3-sdk/utils/contentScript/insertStyleElement.ts
+++ b/extension-files/bringweb3-sdk/utils/contentScript/insertStyleElement.ts
@@ -12,7 +12,9 @@ const insertStyleElement = (css: string | undefined, id: string) => {
     styleElement.id = id;
     styleElement.textContent = css;
 
-    document.head.appendChild(styleElement);
+    // An INJECT arriving very early can land before <head> is parsed;
+    // documentElement always exists, and a <style> outside <head> still applies.
+    (document.head || document.documentElement).appendChild(styleElement);
 
     // Return cleanup function
     contentScriptCleanup.add(() => {


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/504
______
Remix-style hosts (hydrateRoot(document, ...)) regenerate <html> on hydration recovery, deleting our iframe. Re-inject via a bounded MutationObserver (max 3, disarms 2s after load); every intentional teardown path disconnects the observer first so it never fights our own cleanup.

Related hardening in the same flow:
- Derive isIframeOpen from the DOM instead of a flag the host can desync
- Route the iframe's own CLOSE through removeElements so the observer doesn't read it as a host wipe
- Don't report no_popup when the reply is "iframe already open"
- Restore flowId on the activated popup INJECT
- Tolerate document_start injection when <head> doesn't exist yet
- Simplify navUrls to Map<number, string> (history field was never read)